### PR TITLE
fix(docs): remove duplicate @types/morgan from dependencies

### DIFF
--- a/apps/web/src/content/docs/contributing/foundation.mdx
+++ b/apps/web/src/content/docs/contributing/foundation.mdx
@@ -104,7 +104,6 @@ The example below references the demo foundation:
               "tsx",
               "morgan",
               "@types/cors",
-              "@types/morgan",
               "@types/cookie-parser",
               "prettier",
               "@commitlint/cli",


### PR DESCRIPTION
- Deleted redundant @types/morgan entry in contributing foundation dependencies list
- Cleaned up package references for better clarity and maintenance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated foundation documentation examples to reflect current development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->