### PR TITLE
fix(source): correct slug path in registry type items

### DIFF
--- a/apps/web/src/lib/source.ts
+++ b/apps/web/src/lib/source.ts
@@ -118,7 +118,7 @@ export function getRegistryTypeItems(
       meta: {
         databases: item.meta?.databases?.map(db => ({
           ...db,
-          slug: `${framework}/schemas/${db.slug}`
+          slug: `${framework}/${item.type}s/${db.slug}`
         }))
       },
       type: item.type


### PR DESCRIPTION
- Update slug to use `${framework}/${item.type}s/${db.slug}` format
- Replace incorrect `${framework}/schemas/${db.slug}` structure
- Ensure slug matches the item type dynamically for accuracy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated item path structure to dynamically adjust based on item type (schemas, blueprints, and more) for improved consistency and flexibility across the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->