### PR TITLE
feat(cli): add Prisma MongoDB starter option for database configuration

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -44,6 +44,11 @@ export async function init(foundation?: string, options: AddOptions = {}) {
           value: "mongoose-starter"
         },
         {
+          title: "Express + MongoDB (Prisma)",
+          description: "MongoDB database with Prisma ORM",
+          value: "prisma-mongodb-starter"
+        },
+        {
           title: "Express + MySQL (Drizzle)",
           description: "MySQL database with Drizzle ORM",
           value: "drizzle-mysql-starter"

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -33,6 +33,11 @@ export function getDatabaseConfig(foundation: string): DatabaseConfig | null {
         engine: "postgresql",
         adapter: "drizzle"
       };
+    case "prisma-mongodb-starter":
+      return {
+        engine: "mongodb",
+        adapter: "prisma"
+      };
     default:
       return null;
   }


### PR DESCRIPTION
- Add "Express + MongoDB (Prisma)" starter option to init command with description
- Implement database config case for "prisma-mongodb-starter" returning MongoDB engine and Prisma adapter
- Extend CLI to support Prisma ORM for MongoDB setups alongside existing options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Express + MongoDB (Prisma) as a new foundation option during project initialization, enabling developers to quickly bootstrap projects with MongoDB database and Prisma ORM integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->