### PR TITLE
docs(express): update starter guides with improved TS config and docs…

### DIFF
--- a/apps/web/src/content/docs/express/foundations/drizzle-mysql-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/drizzle-mysql-starter.mdx
@@ -565,11 +565,33 @@ mvc_structure:
           "esModuleInterop": true,
           "skipLibCheck": true,
           "outDir": "dist",
-          "rootDir": "src"
+          "rootDir": "src",
+          "sourceMap": true,
+          "alwaysStrict": true,
+          "useUnknownInCatchVariables": true,
+          "forceConsistentCasingInFileNames": true,
+          "paths": {
+            "@/*": [
+              "./*",
+              "./src/*"
+            ],
+            "@/shared/*": [
+              "../../shared/*"
+            ]
+          }
         },
-        "include": ["src/**/*"],
-        "exclude": ["node_modules"]
+        "tsc-alias": {
+          "resolveFullPaths": true,
+          "verbose": false
+        },
+        "include": [
+          "src/**/*"
+        ],
+        "exclude": [
+          "node_modules"
+        ]
       }
+
 
 feature_structure:
   - type: folder
@@ -1156,26 +1178,45 @@ feature_structure:
           "esModuleInterop": true,
           "skipLibCheck": true,
           "outDir": "dist",
-          "rootDir": "src"
+          "rootDir": "src",
+          "sourceMap": true,
+          "alwaysStrict": true,
+          "useUnknownInCatchVariables": true,
+          "forceConsistentCasingInFileNames": true,
+          "paths": {
+            "@/*": [
+              "./*",
+              "./src/*"
+            ],
+            "@/shared/*": [
+              "../../shared/*"
+            ]
+          }
         },
-        "include": ["src/**/*"],
-        "exclude": ["node_modules"]
+        "tsc-alias": {
+          "resolveFullPaths": true,
+          "verbose": false
+        },
+        "include": [
+          "src/**/*"
+        ],
+        "exclude": [
+          "node_modules"
+        ]
       }
+
 ---
 
 # Drizzle MySQL Starter
 
-The **Drizzle MySQL Starter** is a database foundation provided by **servercn** for projects that use **MySQL with Drizzle ORM**. When you run:
+The **Drizzle MySQL Starter** is a database foundation provided by **servercn** for projects that use **MySQL with Drizzle ORM**.
+
+[Drizzle Official Docs](https://orm.drizzle.team/docs/get-started/mysql-new)
 
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli init drizzle-mysql-starter" />
 
-you get a **production‑ready MySQL + Drizzle setup** that integrates cleanly with the Express Starter Foundation.
-
-This starter focuses on **type‑safe database access, clear schema ownership, and predictable migrations**, without hiding SQL or introducing heavy abstractions.
-
-[Official Docs](https://orm.drizzle.team/docs/express/get-started)
 
 ## What This Starter Solves
 

--- a/apps/web/src/content/docs/express/foundations/drizzle-pg-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/drizzle-pg-starter.mdx
@@ -554,10 +554,31 @@ mvc_structure:
           "esModuleInterop": true,
           "skipLibCheck": true,
           "outDir": "dist",
-          "rootDir": "src"
+          "rootDir": "src",
+          "sourceMap": true,
+          "alwaysStrict": true,
+          "useUnknownInCatchVariables": true,
+          "forceConsistentCasingInFileNames": true,
+          "paths": {
+            "@/*": [
+              "./*",
+              "./src/*"
+            ],
+            "@/shared/*": [
+              "../../shared/*"
+            ]
+          }
         },
-        "include": ["src/**/*"],
-        "exclude": ["node_modules"]
+        "tsc-alias": {
+          "resolveFullPaths": true,
+          "verbose": false
+        },
+        "include": [
+          "src/**/*"
+        ],
+        "exclude": [
+          "node_modules"
+        ]
       }
 
 feature_structure:
@@ -1145,26 +1166,44 @@ feature_structure:
           "esModuleInterop": true,
           "skipLibCheck": true,
           "outDir": "dist",
-          "rootDir": "src"
+          "rootDir": "src",
+          "sourceMap": true,
+          "alwaysStrict": true,
+          "useUnknownInCatchVariables": true,
+          "forceConsistentCasingInFileNames": true,
+          "paths": {
+            "@/*": [
+              "./*",
+              "./src/*"
+            ],
+            "@/shared/*": [
+              "../../shared/*"
+            ]
+          }
         },
-        "include": ["src/**/*"],
-        "exclude": ["node_modules"]
+        "tsc-alias": {
+          "resolveFullPaths": true,
+          "verbose": false
+        },
+        "include": [
+          "src/**/*"
+        ],
+        "exclude": [
+          "node_modules"
+        ]
       }
 ---
 
 # Drizzle PostgreSQL Starter
 
-The **Drizzle PostgreSQL Starter** is a database foundation provided by **servercn** for projects that use **PostgreSQL with Drizzle ORM**. When you run:
+The **Drizzle PostgreSQL Starter** is a database foundation provided by **servercn** for projects that use **PostgreSQL with Drizzle ORM**. 
+
+[Drizzle Official Docs](https://orm.drizzle.team/docs/get-started/postgresql-new)
 
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli init drizzle-pg-starter" />
 
-You get a **production‑ready PostgreSQL + Drizzle setup** that integrates cleanly with the Express Starter Foundation.
-
-This starter focuses on **type‑safe database access, clear schema ownership, and predictable migrations**, without hiding SQL or introducing heavy abstractions.
-
-[Official Docs](https://orm.drizzle.team/docs/express/get-started/postgresql-new)
 
 ## What This Starter Solves
 

--- a/apps/web/src/content/docs/express/foundations/express-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/express-starter.mdx
@@ -1057,6 +1057,8 @@ The **Express Starter Foundation** is the core starting block provided by **serv
 
 This foundation is not a framework; it's a well-structured boilerplate that you fully own and can extend as your project grows.
 
+[Expressjs Official Docs](https://expressjs.com)
+
 ## Installation Guide
 
 To install the Express Starter Foundation, run the following command:

--- a/apps/web/src/content/docs/express/foundations/mongoose-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/mongoose-starter.mdx
@@ -1108,17 +1108,15 @@ feature_structure:
 
 # Mongoose Starter
 
-The **Mongoose Starter** is a database foundation provided by **servercn** for projects that use **MongoDB with Mongoose ODM**. When you run:
+The **Mongoose Starter** is a database foundation provided by **servercn** for projects that use **MongoDB with Mongoose ODM**.
+
+[Mongoose Official Docs](https://mongoosejs.com/docs/guide.html)
 
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli init mongoose-starter" />
 
-you get a **production‑ready MongoDB + Mongoose setup** that integrates cleanly with the Express Starter Foundation.
 
-This starter focuses on **schema-based modeling, powerful validation, and developer productivity**, providing a structured way to interact with MongoDB.
-
-[Official Docs](https://mongoosejs.com/docs/express/guide.html)
 
 ## What This Starter Solves
 


### PR DESCRIPTION
… links

- Add detailed TypeScript compiler options for drizzle-mysql and drizzle-pg starters
- Include tsc-alias configuration to support path alias resolution
- Add official documentation links to Drizzle MySQL, Drizzle PostgreSQL, and Mongoose starters
- Remove redundant setup description for database starters to streamline content
- Add Express.js official docs link to Express Starter Foundation installation guide
- Format installation guide sections consistently across all starters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Express, Drizzle MySQL, Drizzle PostgreSQL, and Mongoose starter guides with refreshed setup instructions and configuration guidance.
  * Added links to official framework documentation in starter guides.
  * Reorganized starter project structures for improved clarity and maintainability.
  * Enhanced "What You Get Out of the Box" sections to better reflect available features and components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->