### PR TITLE
fix: add try-catch around JSON.parse(userData) in auth services

### DIFF
--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/src/modules/auth/auth.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/src/modules/auth/auth.service.ts
@@ -120,7 +120,13 @@ export class AuthService {
       throw ApiError.badRequest("Invalid or expired otp");
     }
 
-    const { name, email: userEmail, role, password } = JSON.parse(userData);
+    let parsedData;
+    try {
+      parsedData = JSON.parse(userData);
+    } catch {
+      throw ApiError.badRequest("Invalid user data format");
+    }
+    const { name, email: userEmail, role, password } = parsedData;
 
     const user = await User.create({
       name,

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/src/services/auth.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/src/services/auth.service.ts
@@ -120,7 +120,13 @@ export class AuthService {
       throw ApiError.badRequest("Invalid or expired otp");
     }
 
-    const { name, email: userEmail, role, password } = JSON.parse(userData);
+    let parsedData;
+    try {
+      parsedData = JSON.parse(userData);
+    } catch {
+      throw ApiError.badRequest("Invalid user data format");
+    }
+    const { name, email: userEmail, role, password } = parsedData;
 
     const user = await User.create({
       name,

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/src/modules/auth/auth.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/src/modules/auth/auth.service.ts
@@ -124,7 +124,13 @@ export class AuthService {
       throw ApiError.badRequest("Invalid or expired otp");
     }
 
-    const { name, email: userEmail, role, password } = JSON.parse(userData);
+    let parsedData;
+    try {
+      parsedData = JSON.parse(userData);
+    } catch {
+      throw ApiError.badRequest("Invalid user data format");
+    }
+    const { name, email: userEmail, role, password } = parsedData;
     const enforcedRole = "user" as const;
 
     if (role && role !== enforcedRole) {

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/src/services/auth.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/src/services/auth.service.ts
@@ -134,7 +134,13 @@ export class AuthService {
       throw ApiError.badRequest("Invalid or expired otp");
     }
 
-    const { name, email: userEmail, role, password } = JSON.parse(userData);
+    let parsedData;
+    try {
+      parsedData = JSON.parse(userData);
+    } catch {
+      throw ApiError.badRequest("Invalid user data format");
+    }
+    const { name, email: userEmail, role, password } = parsedData;
 
     const [user] = await db.insert(users).values({
       name,

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/src/modules/auth/auth.service.ts
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/src/modules/auth/auth.service.ts
@@ -93,7 +93,13 @@ export class AuthService {
       throw ApiError.badRequest("Invalid or expired otp");
     }
 
-    const { name, email: userEmail, role, password } = JSON.parse(userData);
+    let parsedData;
+    try {
+      parsedData = JSON.parse(userData);
+    } catch {
+      throw ApiError.badRequest("Invalid user data format");
+    }
+    const { name, email: userEmail, role, password } = parsedData;
 
     const [existingUser] = await db
       .insert(users)

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/src/services/auth.service.ts
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/src/services/auth.service.ts
@@ -90,7 +90,13 @@ export class AuthService {
       throw ApiError.badRequest("Invalid or expired otp");
     }
 
-    const { name, email: userEmail, role, password } = JSON.parse(userData);
+    let parsedData;
+    try {
+      parsedData = JSON.parse(userData);
+    } catch {
+      throw ApiError.badRequest("Invalid user data format");
+    }
+    const { name, email: userEmail, role, password } = parsedData;
 
     const [existingUser] = await db
       .insert(users)


### PR DESCRIPTION
## Summary
`JSON.parse(userData)` in the auth service `verifyEmail` flow can throw `SyntaxError` if Redis stores corrupted/invalid JSON. While the null check validates `userData` exists, it doesn't validate JSON format.

Added try-catch with `ApiError.badRequest` across all 6 affected template variants (hybrid-auth and stateless-auth for MongoDB, PostgreSQL, MySQL).

## Test plan
- [ ] Valid OTP verification flow still works
- [ ] Corrupted Redis data returns 400 instead of crashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in authentication services across multiple templates. When user data cannot be processed, the system now returns a clear, user-friendly error message instead of exposing technical errors, improving the reliability of authentication operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->