### PR TITLE
feat/cli generator

### DIFF
--- a/packages/cli/src/commands/generator/generator.handlers.ts
+++ b/packages/cli/src/commands/generator/generator.handlers.ts
@@ -5,6 +5,8 @@ import { resolvePath, writeFileSafe } from "@/utils/file";
 import { toKebabCase, toPascalCase } from "@/utils/naming";
 import { compileTemplate } from "@/utils/template";
 
+import { resolve } from "path";
+
 import { validateStack } from "@/commands/add";
 import type { Architecture, GeneratorType } from "@/types";
 import { logger } from "@/utils/logger";
@@ -98,6 +100,15 @@ export async function generateResource(
   await generateService(name, options);
   await generateRoute(name, options);
   await generateModel(name, options);
+  await generateDTO({
+    name,
+    fields: [],
+    options: {
+      ...options,
+      flat: true
+    },
+    type: "dto"
+  });
 }
 
 export async function generateModel(name: string, options?: GeneratorOptions) {
@@ -114,6 +125,75 @@ export async function generateRoute(name: string, options?: GeneratorOptions) {
     type: "route",
     options
   });
+}
+
+export async function generateDTO({
+  name,
+  fields,
+  options,
+  type
+}: {
+  name: string;
+  fields: string[];
+  options: GeneratorOptions;
+  type: "dto" | "validator";
+}) {
+  await assertInitialized();
+
+  const config = await getServerCNConfig();
+  validateStack(config);
+
+  const { architecture } = config;
+
+  const fileName = `${toKebabCase(name)}.${type}.ts`;
+
+  const outputPath = resolveDTOPath({
+    name,
+    fileName,
+    architecture,
+    flat: options.flat,
+    type
+  });
+
+  const className = toPascalCase(name);
+
+  const parsedFields = parseFields(fields || []);
+
+  const content = buildDTOContent({
+    name,
+    className,
+    fields: parsedFields,
+    crud: true,
+    type
+  });
+
+  await writeFileSafe({
+    filePath: outputPath,
+    content,
+    force: options.force
+  });
+}
+
+function resolveDTOPath({
+  name,
+  fileName,
+  architecture,
+  flat,
+  type
+}: {
+  name: string;
+  fileName: string;
+  architecture: string;
+  flat?: boolean;
+  type: "dto" | "validator";
+}) {
+  if (architecture === "feature") {
+    return flat
+      ? resolve(`src/modules/${toKebabCase(name)}`, fileName)
+      : resolve(`src/modules/${toKebabCase(name)}/${type}s`, fileName);
+  }
+
+  return resolve(`src/${type}s`, fileName);
 }
 
 function resolveOutputPath({
@@ -140,6 +220,8 @@ function resolveOutputPath({
       return resolvePath("src/services", fileName);
     } else if (type === "route") {
       return resolvePath("src/routes", fileName);
+    } else if (type === "dto") {
+      return resolvePath("src/dtos", fileName);
     }
   }
 
@@ -152,7 +234,9 @@ export function resolveGeneratorType(type: GeneratorType) {
     se: "service",
     mo: "model",
     ro: "route",
-    re: "resource"
+    re: "resource",
+    dt: "dto",
+    va: "validator"
   };
 
   const resolved = typeAliases[type] || type;
@@ -164,9 +248,90 @@ export function resolveGeneratorType(type: GeneratorType) {
     logger.info(" → service (se)");
     logger.info(" → model (mo)");
     logger.info(" → route (ro)");
-    logger.info(" → resource (re)");
+    logger.info(" → dt (dto)");
+    logger.info(" → va (validator)");
+    logger.info(
+      " → re (re → controller, service, route, model, dto, validator)"
+    );
     process.exit(1);
   }
 
   return resolved;
+}
+
+function parseFields(fields: string[]) {
+  return fields.map(field => {
+    const [key, type] = field.split(":");
+
+    return {
+      key,
+      type: type || "string"
+    };
+  });
+}
+
+function mapToZod(type: string) {
+  switch (type) {
+    case "string":
+      return "z.string()";
+    case "number":
+      return "z.number()";
+    case "url":
+      return "z.url()";
+    case "boolean":
+      return "z.boolean()";
+    case "email":
+      return "z.email()";
+    case "date":
+      return "z.coerce.date()";
+    default:
+      return "z.string()";
+  }
+}
+
+function buildDTOContent({
+  name,
+  className,
+  fields,
+  crud,
+  type
+}: {
+  name: string;
+  className: string;
+  fields: {
+    key: string;
+    type: string;
+  }[];
+  crud: boolean;
+  type: "dto" | "validator";
+}) {
+  const baseFields =
+    fields.length > 0
+      ? fields.map(f => `  ${f.key}: ${mapToZod(f.type)},`).join("\n")
+      : `  // TODO: define fields
+  name: z.string().min(2),`;
+
+  return `import { z } from "zod";
+
+//* Base schema for ${className}
+export const ${name}BaseSchema = z.object({
+${baseFields}
+});
+
+${
+  crud
+    ? `
+//* Create ${className} ${type}
+export const Create${className}${capitalize(type)} = ${name}BaseSchema;
+
+export type Create${className}${capitalize(type)}Type = z.infer<typeof Create${className}${capitalize(type)}>;
+
+//* Update ${className} ${type}
+export const Update${className}${capitalize(type)} = ${name}BaseSchema.partial();
+
+export type Update${className}${capitalize(type)}Type = z.infer<typeof Update${className}${capitalize(type)}>;
+`
+    : ""
+}
+`;
 }

--- a/packages/cli/src/commands/generator/index.ts
+++ b/packages/cli/src/commands/generator/index.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import {
   generateController,
+  generateDTO,
   generateModel,
   generateResource,
   generateRoute,
@@ -12,18 +13,20 @@ import ora from "ora";
 
 export interface GeneratorOptions {
   force?: boolean;
+  flat?: boolean;
+  fields?: string[];
 }
 
 export function registryGeneratorCommand(program: Command) {
   const generateCommand = program
-    .command("generate <type> <name>")
+    .command("generate <type> <name> [fields...]")
     .alias("g")
     .description(
-      "Generate resources (controller, service, resource, model, route, etc.)"
+      "Generate resources (controller, service, resource, model, route, dto, validator, etc.)"
     )
     .option("--force", "Overwrite existing files")
-
-    .action(async (type, name, options: GeneratorOptions) => {
+    .option("--flat", "Generate files in a flat structure")
+    .action(async (type, name, fields, options: GeneratorOptions) => {
       try {
         const generators = {
           controller: generateController,
@@ -39,10 +42,15 @@ export function registryGeneratorCommand(program: Command) {
         });
 
         spinner.start();
+
         const resolvedType = resolveGeneratorType(type);
         const generator = generators[resolvedType as keyof typeof generators];
 
-        if (!generator) {
+        if (
+          !generator &&
+          resolvedType !== "dto" &&
+          resolvedType !== "validator"
+        ) {
           spinner.stop();
           logger.error(`Unknown generator type: ${type}\n`);
 
@@ -52,12 +60,23 @@ export function registryGeneratorCommand(program: Command) {
           logger.info(" → model (mo)");
           logger.info(" → route (ro)");
           logger.info(" → resource (re)");
+          logger.info(" → dt (dto)");
 
           process.exit(1);
         }
 
         logger.break();
-        await generator(name, options);
+
+        if (resolvedType === "dto" || resolvedType === "validator") {
+          await generateDTO({
+            name,
+            fields,
+            options,
+            type: resolvedType
+          });
+        } else {
+          await generator(name, options);
+        }
 
         logger.break();
         spinner.succeed(`Successfully generated ${resolvedType}: ${name}`);
@@ -78,6 +97,8 @@ Aliases:
   mo → model
   ro → route
   re → resource
+  dt → dto
+  va → validator
 
 Examples:
   $ npx servercn-cli g co user
@@ -85,6 +106,8 @@ Examples:
   $ npx servercn-cli g mo user
   $ npx servercn-cli g ro user
   $ npx servercn-cli g se user
+  $ npx servercn-cli g dt user
+  $ npx servercn-cli g va user
 `
   );
 }

--- a/packages/cli/src/constants/app.constants.ts
+++ b/packages/cli/src/constants/app.constants.ts
@@ -39,5 +39,7 @@ export const GENERATOR_TYPES = [
   "service",
   "route",
   "model",
-  "resource"
+  "resource",
+  "dto",
+  "validator"
 ] as const;

--- a/packages/cli/src/lib/registry.ts
+++ b/packages/cli/src/lib/registry.ts
@@ -20,7 +20,9 @@ export async function getRegistry<T extends keyof RegistryMap>(
 
   if (local) {
     const registryPath = paths.localRegistry(type);
-
+    console.log({
+      registryPath
+    });
     if (!(await fs.pathExists(registryPath))) {
       logger.break();
       logger.error(

--- a/packages/cli/src/utils/tooling.ts
+++ b/packages/cli/src/utils/tooling.ts
@@ -50,12 +50,13 @@ export async function getToolingChoices(): Promise<ToolingKey[]> {
     message: "Choose tooling setup:",
     choices: [
       {
-        title: "Prettier + ESLint + TypeScript",
-        value: "recommended"
+        title:
+          "All (Prettier + ESLint + TypeScript + Husky + Lint Staged + Commitlint)",
+        value: "all"
       },
       {
-        title: "All (Prettier + ESLint + TypeScript + Husky + Lint Staged + Commitlint)",
-        value: "all"
+        title: "Prettier + ESLint + TypeScript",
+        value: "recommended"
       },
       { title: "Custom", value: "custom" }
     ]


### PR DESCRIPTION
- Add new generator types: 'dto' and 'validator' with alias support
- Support dynamic field definitions via [fields...] argument
- Add --flat option for generating files in flat structure
- Update help text and examples to include new generators
- Extend generator options interface with fields and flat properties

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DTO and validator generator types with field definition support.
  * Extended CLI generator command to accept field parameters and flat directory layout option.
  * Added command type aliases for quicker code generation.

* **Chores**
  * Enhanced registry path logging for debugging.
  * Reorganized tooling setup prompt options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->