### PR TITLE
feat(foundation): add drizzle-neon-pg starter configuration

### DIFF
--- a/packages/registry/foundation/drizzle-neon-pg-starter.json
+++ b/packages/registry/foundation/drizzle-neon-pg-starter.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://servercn.vercel.app/schema/foundation.registry.json",
+  "slug": "drizzle-neon-pg",
+  "runtimes": {
+    "node": {
+      "frameworks": {
+        "express": {
+          "templates": {
+            "mvc": "drizzle-neon-pg/mvc",
+            "feature": "drizzle-neon-pg/feature"
+          },
+          "dependencies": {
+            "runtime": [
+              "express",
+              "cors",
+              "helmet",
+              "cookie-parser",
+              "drizzle-orm",
+              "@neondatabase/serverless",
+              "pino-pretty",
+              "pino",
+              "dotenv-flow",
+              "cross-env",
+              "source-map-support",
+              "zod",
+              "swagger-autogen",
+              "swagger-ui-express"
+            ],
+            "dev": [
+              "@types/express",
+              "morgan",
+              "@types/cors",
+              "@types/morgan",
+              "@types/cookie-parser",
+              "drizzle-kit",
+              "@types/source-map-support",
+              "@types/swagger-ui-express"
+            ]
+          },
+          "env": [
+            "LOG_LEVEL",
+            "NODE_ENV",
+            "PORT",
+            "CORS_ORIGIN",
+            "DATABASE_URL"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds a new registry entry for the Drizzle ORM with Neon PostgreSQL starter. This includes runtime configuration for Node.js with Express, defining templates (MVC and feature), dependencies (runtime and dev), and required environment variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Drizzle Neon PostgreSQL starter template to the registry with Express.js framework, ORM integration, built-in security and logging middleware, Swagger API documentation support, schema validation with Zod, and complete TypeScript development environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->