### PR TITLE
chore(cli): bump servercn-cli version to 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22587,7 +22587,7 @@
     },
     "packages/cli": {
       "name": "servercn-cli",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
         "cli-table3": "^0.6.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servercn-cli",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Backend components CLI for Node.js & Typescript",
   "main": "dist/cli.js",
   "readme": "README.md",


### PR DESCRIPTION
chore(cli): bump servercn-cli version to 2.0.4 in package.json and package-lock.json