### PR TITLE
feat(provider): add pg-drizzle-neon configuration for PostgreSQL inte…

### DIFF
--- a/packages/registry/provider/pg-drizzle-neon.json
+++ b/packages/registry/provider/pg-drizzle-neon.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://servercn.vercel.app/schema/foundation.registry.json",
+  "slug": "pg-drizzle-neon",
+  "runtimes": {
+    "node": {
+      "frameworks": {
+        "express": {
+          "templates": {
+            "mvc": "pg-drizzle-neon/mvc",
+            "feature": "pg-drizzle-neon/feature"
+          },
+          "dependencies": {
+            "runtime": ["drizzle-orm", "@neondatabase/serverless"],
+            "dev": ["drizzle-kit"]
+          },
+          "env": ["DATABASE_URL"]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
…gration

Introduces a new JSON configuration file for the pg-drizzle-neon provider, defining runtime settings, frameworks, templates, and dependencies for an Express application. This enhances support for PostgreSQL in the project.