### PR TITLE
feat(provider): update command syntax for provider installations

### DIFF
--- a/apps/web/src/components/docs/icons/language-icons.tsx
+++ b/apps/web/src/components/docs/icons/language-icons.tsx
@@ -594,7 +594,7 @@ export function getIconForLanguageExtension(
   if (fileName?.endsWith(".jsx")) {
     return <LanguageIcons.tsx className="size-4" />;
   }
-  if (fileName?.endsWith(".gitignore")) {
+  if (fileName?.endsWith(".gitignore") || fileName?.endsWith(".gitkeep")) {
     return <FaGitAlt className="size-4 text-[#e64a19]" />;
   }
   if (fileName?.endsWith(".ejs") || fileName?.endsWith(".html")) {

--- a/apps/web/src/content/docs/cli/commands.mdx
+++ b/apps/web/src/content/docs/cli/commands.mdx
@@ -167,7 +167,7 @@ Blueprints accelerate feature-level development while preserving architectural c
 
 Install a provider integration for external services, databases.
 
-<PackageManagerTabs command="npx servercn-cli add provider <provider-name>" />
+<PackageManagerTabs command="npx servercn-cli add pr <provider-name>" />
 
 <PackageManagerTabs command="npx servercn-cli add pr mongodb-prisma" />
 

--- a/apps/web/src/content/docs/express/providers/cloudinary-storage.mdx
+++ b/apps/web/src/content/docs/express/providers/cloudinary-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cloudinary Storage | Provider
 description: Cloudinary media upload and storage provider with Multer for Express applications.
-command: npx servercn-cli add provider cloudinary-storage
+command: npx servercn-cli add pr cloudinary-storage
 ---
 
 # Cloudinary Storage Provider
@@ -18,20 +18,6 @@ This provider adds [Cloudinary](https://cloudinary.com/) SDK configuration, Zod-
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli add pr cloudinary-storage" />
-
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/cloudinary.ts" />
-- <Code children="src/middlewares/upload-file.ts" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/shared/configs/cloudinary.ts" />
-- <Code children="src/shared/middlewares/upload-file.ts" />
 
 ## Environment Configuration
 

--- a/apps/web/src/content/docs/express/providers/imagekit-storage.mdx
+++ b/apps/web/src/content/docs/express/providers/imagekit-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: ImageKit Storage | Provider
 description: ImageKit file upload and CDN storage provider with Multer for Express applications.
-command: npx servercn-cli add provider imagekit-storage
+command: npx servercn-cli add pr imagekit-storage
 ---
 
 # ImageKit Storage Provider
@@ -18,20 +18,6 @@ This provider adds the [ImageKit Node SDK](https://github.com/imagekit-developer
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli add pr imagekit-storage" />
-
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/imagekit.ts" />
-- <Code children="src/middlewares/upload-file.ts" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/shared/configs/imagekit.ts" />
-- <Code children="src/shared/middlewares/upload-file.ts" />
 
 ## Environment Configuration
 

--- a/apps/web/src/content/docs/express/providers/mongodb-mongoose.mdx
+++ b/apps/web/src/content/docs/express/providers/mongodb-mongoose.mdx
@@ -1,36 +1,21 @@
 ---
 title: Mongodb(Mongoose) | Provider
 description: MongoDB provider with Mongoose ORM for Express applications.
-command: npx servercn-cli add provider mongodb-mongoose
+command: npx servercn-cli add pr mongodb-mongoose
 ---
 
 # Mongodb(Mongoose) Provider
 
-This provider sets up MongoDB connectivity with Mongoose for Express projects, including environment validation, a database connection helper, and a logger.
+This provider sets up MongoDB connectivity with Mongoose for Express projects, including environment validation, a database connection helper.
 
 ## Features
 
 - Type-safe environment validation with Zod
 - Ready-to-use MongoDB connection helper
-- Pino logger configured for dev and production
 
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli add pr mongodb-mongoose" />
-
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/db.ts" />
-- <Code children="src/utils/logger.ts" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/db/db.ts" />
-- <Code children="src/shared/utils/logger.ts" />
 
 ## Environment Configuration
 
@@ -41,15 +26,7 @@ import "dotenv-flow/config";
 import { z } from "zod";
 
 export const envSchema = z.object({
-  NODE_ENV: z
-    .enum(["development", "test", "production"])
-    .default("development"),
-  PORT: z.string().regex(/^\d+$/, "PORT must be a number").transform(Number),
   DATABASE_URL: z.url(),
-  CORS_ORIGIN: z.url(),
-  LOG_LEVEL: z
-    .enum(["fatal", "error", "warn", "info", "debug", "trace"])
-    .default("info")
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -74,7 +51,6 @@ export default env;
 ```ts
 import mongoose from "mongoose";
 import env from "./env";
-import { logger } from "../utils/logger";
 
 if (!env.DATABASE_URL) {
   throw new Error("Please provide DATABASE_URL in the environment variables");
@@ -83,36 +59,14 @@ if (!env.DATABASE_URL) {
 export const connectDB = async (): Promise<void> => {
   try {
     const conn = await mongoose.connect(env.DATABASE_URL as string);
-    logger.info(`MongoDB Connected: ${conn.connection.host}`);
+    console.log(`MongoDB Connected: ${conn.connection.host}`);
   } catch (error) {
-    logger.error(error, "MongoDB Connection Failed:");
+    console.error("MongoDB Connection Failed:", error);
     process.exit(1);
   }
 };
-```
 
-## Logger
 
-<Code children="src/utils/logger.ts" />
-
-```ts
-import pino from "pino";
-import env from "../configs/env";
-
-export const logger = pino({
-  level: env.LOG_LEVEL,
-  transport:
-    env.NODE_ENV !== "production"
-      ? {
-          target: "pino-pretty",
-          options: {
-            colorize: true,
-            translateTime: "yyyy-mm-dd HH:MM:ss",
-            ignore: "pid,hostname"
-          }
-        }
-      : undefined
-});
 ```
 
 ## Usage
@@ -126,9 +80,5 @@ await connectDB();
 ## Example .env
 
 ```bash
-NODE_ENV=development
-PORT=8000
 DATABASE_URL=mongodb://localhost:27017/app
-CORS_ORIGIN=http://localhost:3000
-LOG_LEVEL=info
 ```

--- a/apps/web/src/content/docs/express/providers/mongodb-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/mongodb-prisma.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mongodb(Prisma) | Provider
 description: MongoDB provider with Prisma ORM for Express applications.
-command: npx servercn-cli add provider mongodb-prisma
+command: npx servercn-cli add pr mongodb-prisma
 ---
 
 # Mongodb(Prisma) Provider
@@ -18,20 +18,6 @@ This provider sets up MongoDB connectivity with Prisma for Express projects, inc
 
 <PackageManagerTabs command="npx servercn-cli add pr mongodb-prisma" />
 
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/prisma.ts" />
-- <Code children="src/prisma/schema.prisma" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/shared/configs/prisma.ts" />
-- <Code children="src/prisma/schema.prisma" />
-
 ## Environment Configuration
 
 <Code children="src/configs/env.ts" />
@@ -43,13 +29,9 @@ import { z } from "zod";
 export const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "test", "production"])
-    .default("development"),
-  PORT: z.string().regex(/^\d+$/, "PORT must be a number").transform(Number),
+    .default("development")
+
   DATABASE_URL: z.url(),
-  CORS_ORIGIN: z.url(),
-  LOG_LEVEL: z
-    .enum(["fatal", "error", "warn", "info", "debug", "trace"])
-    .default("info")
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -116,8 +98,6 @@ const users = await prisma.user.findMany();
 
 ```bash
 NODE_ENV=development
-PORT=8000
+
 DATABASE_URL=mongodb://localhost:27017/app
-CORS_ORIGIN=http://localhost:3000
-LOG_LEVEL=info
 ```

--- a/apps/web/src/content/docs/express/providers/mysql-drizzle.mdx
+++ b/apps/web/src/content/docs/express/providers/mysql-drizzle.mdx
@@ -1,36 +1,22 @@
 ---
 title: Mysql(Drizzle) | Provider
 description: Mysql provider with Drizzle ORM for Express applications.
-command: npx servercn-cli add provider mysql-drizzle
+command: npx servercn-cli add pr mysql-drizzle
 ---
 
 # Mysql(Drizzle) Provider
 
-This provider sets up MySQL connectivity with Drizzle ORM for Express projects, including environment validation, a database client, and a logger.
+This provider sets up MySQL connectivity with Drizzle ORM for Express projects, including environment validation, a database client.
 
 ## Features
 
 - Type-safe environment validation with Zod
 - Ready-to-use Drizzle client for MySQL
-- Pino logger configured for dev and production
 
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli add pr mysql-drizzle" />
 
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/db.ts" />
-- <Code children="src/utils/logger.ts" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/db/db.ts" />
-- <Code children="src/shared/utils/logger.ts" />
 
 ## Environment Configuration
 
@@ -43,13 +29,9 @@ import { z } from "zod";
 export const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "test", "production"])
-    .default("development"),
-  PORT: z.string().regex(/^\d+$/, "PORT must be a number").transform(Number),
+    .default("development")
+
   DATABASE_URL: z.url(),
-  CORS_ORIGIN: z.url(),
-  LOG_LEVEL: z
-    .enum(["fatal", "error", "warn", "info", "debug", "trace"])
-    .default("info")
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -82,29 +64,6 @@ const db = drizzle(env.DATABASE_URL!, {
 export default db;
 ```
 
-## Logger
-
-<Code children="src/utils/logger.ts" />
-
-```ts
-import pino from "pino";
-import env from "../configs/env";
-
-export const logger = pino({
-  level: env.LOG_LEVEL,
-  transport:
-    env.NODE_ENV !== "production"
-      ? {
-          target: "pino-pretty",
-          options: {
-            colorize: true,
-            translateTime: "yyyy-mm-dd HH:MM:ss",
-            ignore: "pid,hostname"
-          }
-        }
-      : undefined
-});
-```
 
 ## Usage
 
@@ -119,8 +78,6 @@ import db from "./configs/db";
 
 ```bash
 NODE_ENV=development
-PORT=8000
-DATABASE_URL=mysql://username:password@localhost:3306/mydb
-CORS_ORIGIN=http://localhost:3000
-LOG_LEVEL=info
+
+DATABASE_URL=mysql://username:password@localhost:3306/mydbo
 ```

--- a/apps/web/src/content/docs/express/providers/mysql-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/mysql-prisma.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mysql(Prisma) | Provider
 description: Mysql provider with Prisma ORM for Express applications.
-command: npx servercn-cli add provider mysql-prisma
+command: npx servercn-cli add pr mysql-prisma
 ---
 
 # Mysql(Prisma) Provider
@@ -18,20 +18,6 @@ This provider sets up MySQL connectivity with Prisma for Express projects, inclu
 
 <PackageManagerTabs command="npx servercn-cli add pr mysql-prisma" />
 
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/prisma.ts" />
-- <Code children="src/prisma/schema.prisma" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/shared/configs/prisma.ts" />
-- <Code children="src/prisma/schema.prisma" />
-
 ## Environment Configuration
 
 <Code children="src/configs/env.ts" />
@@ -43,13 +29,9 @@ import { z } from "zod";
 export const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "test", "production"])
-    .default("development"),
-  PORT: z.string().regex(/^\d+$/, "PORT must be a number").transform(Number),
+    .default("development")
+
   DATABASE_URL: z.url(),
-  CORS_ORIGIN: z.url(),
-  LOG_LEVEL: z
-    .enum(["fatal", "error", "warn", "info", "debug", "trace"])
-    .default("info")
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -118,8 +100,6 @@ const users = await prisma.user.findMany();
 
 ```bash
 NODE_ENV=development
-PORT=8000
+
 DATABASE_URL=mysql://username:password@localhost:3306/mydb
-CORS_ORIGIN=http://localhost:3000
-LOG_LEVEL=info
 ```

--- a/apps/web/src/content/docs/express/providers/nodemailer-smtp.mdx
+++ b/apps/web/src/content/docs/express/providers/nodemailer-smtp.mdx
@@ -1,7 +1,7 @@
 ---
 title: Nodemailer SMTP | Provider
 description: Transactional email provider using Nodemailer over SMTP for Express applications.
-command: npx servercn-cli add provider nodemailer-smtp
+command: npx servercn-cli add pr nodemailer-smtp
 ---
 
 # Nodemailer SMTP Provider
@@ -18,18 +18,6 @@ This provider configures [Nodemailer](https://nodemailer.com/) with SMTP setting
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli add pr nodemailer-smtp" />
-
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/nodemailer.ts" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/shared/configs/nodemailer.ts" />
 
 ## Environment Configuration
 

--- a/apps/web/src/content/docs/express/providers/pg-drizzle-neon.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-drizzle-neon.mdx
@@ -6,13 +6,12 @@ command: npx servercn-cli add pr pg-drizzle-neon
 
 # PostgreSQL(Drizzle) Provider
 
-This provider sets up PostgreSQL + Neon connectivity with Drizzle ORM for Express projects, including environment validation, a database client, and a logger.
+This provider sets up PostgreSQL + Neon connectivity with Drizzle ORM for Express projects, including environment validation, a database client.
 
 ## Features
 
 - Type-safe environment validation with Zod
 - Ready-to-use Drizzle client for PostgreSQL
-- Pino logger configured for dev and production
 
 ## Installation Guide
 
@@ -30,7 +29,8 @@ import { z } from "zod";
 export const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "test", "production"])
-    .default("development"),
+    .default("development")
+
   DATABASE_URL: z.url(),
 });
 
@@ -77,8 +77,6 @@ import db from "./configs/db";
 
 ```bash
 NODE_ENV=development
-PORT=8000
+
 DATABASE_URL=postgresql://username:password@localhost:5432/mydb?schema=public
-CORS_ORIGIN=http://localhost:3000
-LOG_LEVEL=info
 ```

--- a/apps/web/src/content/docs/express/providers/pg-drizzle.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-drizzle.mdx
@@ -1,36 +1,22 @@
 ---
 title: PostgreSQL(Drizzle) | Provider
 description: PostgreSQL provider with Drizzle ORM for Express applications.
-command: npx servercn-cli add provider pg-drizzle
+command: npx servercn-cli add pr pg-drizzle
 ---
 
 # PostgreSQL(Drizzle) Provider
 
-This provider sets up PostgreSQL connectivity with Drizzle ORM for Express projects, including environment validation, a database client, and a logger.
+This provider sets up PostgreSQL connectivity with Drizzle ORM for Express projects, including environment validation, a database client.
 
 ## Features
 
 - Type-safe environment validation with Zod
 - Ready-to-use Drizzle client for PostgreSQL
-- Pino logger configured for dev and production
 
 ## Installation Guide
 
 <PackageManagerTabs command="npx servercn-cli add pr pg-drizzle" />
 
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/db.ts" />
-- <Code children="src/utils/logger.ts" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/db/db.ts" />
-- <Code children="src/shared/utils/logger.ts" />
 
 ## Environment Configuration
 
@@ -43,13 +29,9 @@ import { z } from "zod";
 export const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "test", "production"])
-    .default("development"),
-  PORT: z.string().regex(/^\d+$/, "PORT must be a number").transform(Number),
-  DATABASE_URL: z.url(),
-  CORS_ORIGIN: z.url(),
-  LOG_LEVEL: z
-    .enum(["fatal", "error", "warn", "info", "debug", "trace"])
-    .default("info")
+    .default("development")
+    
+  DATABASE_URL: z.url()
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -82,29 +64,6 @@ const db = drizzle(env.DATABASE_URL!, {
 export default db;
 ```
 
-## Logger
-
-<Code children="src/utils/logger.ts" />
-
-```ts
-import pino from "pino";
-import env from "../configs/env";
-
-export const logger = pino({
-  level: env.LOG_LEVEL,
-  transport:
-    env.NODE_ENV !== "production"
-      ? {
-          target: "pino-pretty",
-          options: {
-            colorize: true,
-            translateTime: "yyyy-mm-dd HH:MM:ss",
-            ignore: "pid,hostname"
-          }
-        }
-      : undefined
-});
-```
 
 ## Usage
 
@@ -119,8 +78,6 @@ import db from "./configs/db";
 
 ```bash
 NODE_ENV=development
-PORT=8000
+
 DATABASE_URL=postgresql://username:password@localhost:5432/mydb?schema=public
-CORS_ORIGIN=http://localhost:3000
-LOG_LEVEL=info
 ```

--- a/apps/web/src/content/docs/express/providers/pg-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-prisma.mdx
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL(Prisma) | Provider
 description: PostgreSQL provider with Prisma ORM for Express applications.
-command: npx servercn-cli add provider pg-prisma
+command: npx servercn-cli add pr pg-prisma
 ---
 
 # PostgreSQL(Prisma) Provider
@@ -18,20 +18,6 @@ This provider sets up PostgreSQL connectivity with Prisma for Express projects, 
 
 <PackageManagerTabs command="npx servercn-cli add pr pg-prisma" />
 
-## File Structure
-
-### MVC
-
-- <Code children="src/configs/env.ts" />
-- <Code children="src/configs/prisma.ts" />
-- <Code children="src/prisma/schema.prisma" />
-
-### Feature
-
-- <Code children="src/shared/configs/env.ts" />
-- <Code children="src/shared/configs/prisma.ts" />
-- <Code children="src/prisma/schema.prisma" />
-
 ## Environment Configuration
 
 <Code children="src/configs/env.ts" />
@@ -43,13 +29,9 @@ import { z } from "zod";
 export const envSchema = z.object({
   NODE_ENV: z
     .enum(["development", "test", "production"])
-    .default("development"),
-  PORT: z.string().regex(/^\d+$/, "PORT must be a number").transform(Number),
+    .default("development")
+
   DATABASE_URL: z.url(),
-  CORS_ORIGIN: z.url(),
-  LOG_LEVEL: z
-    .enum(["fatal", "error", "warn", "info", "debug", "trace"])
-    .default("info")
 });
 
 export type Env = z.infer<typeof envSchema>;
@@ -118,8 +100,6 @@ const users = await prisma.user.findMany();
 
 ```bash
 NODE_ENV=development
-PORT=8000
+
 DATABASE_URL=postgresql://username:password@localhost:5432/mydb?schema=public
-CORS_ORIGIN=http://localhost:3000
-LOG_LEVEL=info
 ```

--- a/apps/web/src/content/docs/express/providers/redis.mdx
+++ b/apps/web/src/content/docs/express/providers/redis.mdx
@@ -1,7 +1,7 @@
 ---
 title: Redis | Provider
 description: Redis cache and key-value provider with the official Node client for Express applications.
-command: npx servercn-cli add provider redis
+command: npx servercn-cli add pr redis
 ---
 
 # Redis Provider

--- a/apps/web/src/content/docs/express/providers/resend-mail.mdx
+++ b/apps/web/src/content/docs/express/providers/resend-mail.mdx
@@ -1,7 +1,7 @@
 ---
 title: Resend Mail | Provider
 description: Email provider using the Resend API for Express applications.
-command: npx servercn-cli add provider resend-mail
+command: npx servercn-cli add pr resend-mail
 ---
 
 # Resend Mail Provider

--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -768,6 +768,18 @@
       }
     },
     {
+      "slug": "pg-drizzle-neon",
+      "type": "provider",
+      "status": "stable",
+      "frameworks": ["express"],
+      "title": "PostgreSQL Neon (Drizzle)",
+      "description": "PostgreSQL + Neon provider with Drizzle ORM for Express applications.",
+      "docs": "/docs/providers/pg-drizzle-neon",
+      "meta": {
+        "new": true
+      }
+    },
+    {
       "slug": "pg-prisma",
       "type": "provider",
       "status": "stable",


### PR DESCRIPTION
Refactors the command syntax in documentation for various providers to use a shortened format (`pr` instead of `provider`). This change enhances consistency across the documentation and simplifies the installation commands for users. Additionally, updates the language icons to include support for `.gitkeep` files.