### PR TITLE
docs(registry): add nextjs framework to generate-otp-token component

### DIFF
--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -376,7 +376,7 @@
       "description": "Cryptographically secure utility functions for generating OTPs, random tokens, and unique identifiers for authentication workflows.",
       "type": "component",
       "status": "stable",
-      "frameworks": ["express"],
+      "frameworks": ["express", "nextjs"],
       "docs": "/docs/components/generate-otp-token"
     },
     {


### PR DESCRIPTION
Update the registry entry to reflect that the component now supports Next.js in addition to Express.