### PR TITLE
feat/template nextjs rate limiter

### DIFF
--- a/packages/templates/node/nextjs/component/rate-limiter/file-api/src/configs/env.ts
+++ b/packages/templates/node/nextjs/component/rate-limiter/file-api/src/configs/env.ts
@@ -1,0 +1,20 @@
+import z from "zod";
+
+export const envSchema = z.object({
+  UPSTASH_REDIS_REST_TOKEN: z.string(),
+  UPSTASH_REDIS_REST_URL: z.string()
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+const result = envSchema.safeParse(process.env);
+
+if (!result.success) {
+  console.error("❌ Invalid environment configuration");
+  console.error(z.prettifyError(result.error));
+  process.exit(1);
+}
+
+export const env: Readonly<Env> = Object.freeze(result.data);
+
+export default env;

--- a/packages/templates/node/nextjs/component/rate-limiter/file-api/src/configs/redis.ts
+++ b/packages/templates/node/nextjs/component/rate-limiter/file-api/src/configs/redis.ts
@@ -1,0 +1,10 @@
+import { Redis } from "@upstash/redis";
+
+import env from "@/configs/env";
+
+const redis = new Redis({
+  url: env.UPSTASH_REDIS_REST_URL,
+  token: env.UPSTASH_REDIS_REST_TOKEN
+});
+
+export default redis;

--- a/packages/templates/node/nextjs/component/rate-limiter/file-api/src/lib/rate-limiter.ts
+++ b/packages/templates/node/nextjs/component/rate-limiter/file-api/src/lib/rate-limiter.ts
@@ -1,0 +1,75 @@
+import { Ratelimit } from "@upstash/ratelimit";
+
+import redis from "@/configs/redis";
+
+export const ratelimit = new Ratelimit({
+  redis: redis,
+  limiter: Ratelimit.fixedWindow(100, "10 s"), //* 100 requests per 10 seconds
+  ephemeralCache: new Map(), //* cache for the ratelimit
+  prefix: "@servercn/ratelimit" //* prefix for the ratelimit
+});
+
+/**
+ * ? Usage:
+ 
+import { ratelimit } from "@/lib/rate-limiter";
+
+* * 1. proxy.ts (middleware)
+
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export async function proxy(request: NextRequest) {
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "127.0.0.1";
+
+  const { success, limit, remaining } = await ratelimit.limit(ip);
+  const response = NextResponse.next();
+
+  if (!success) {
+    response.headers.set("X-RateLimit-Success", success.toString());
+    response.headers.set("X-RateLimit-Limit", limit.toString());
+    response.headers.set("X-RateLimit-Remaining", remaining.toString());
+    return response;
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/api/:path*"]
+};
+
+* * 2. API Routes
+
+export const POST = async (req: NextRequest) => {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "127.0.0.1";
+
+  const { success, limit, remaining, reset } = await ratelimit.limit(ip);
+
+  if (!success) {
+    return NextResponse.json(
+      {
+        message: "Too many requests, please try again later."
+      },
+      {
+        status: 429,
+        headers: {
+          "X-RateLimit-Limit": limit.toString(),
+          "X-RateLimit-Remaining": remaining.toString(),
+          "X-RateLimit-Reset": reset.toString()
+        }
+      }
+    );
+  }
+
+  //* Your API logic here
+};
+
+** Official Docs:
+* https://upstash.com/docs/redis/sdks/ratelimit-ts/gettingstarted
+* https://github.com/upstash/ratelimit-js/tree/main/examples/nextjs
+* https://github.com/upstash/ratelimit-js/tree/main/examples/nextjs-middleware
+**/


### PR DESCRIPTION
Introduce a new rate limiter module using Upstash Redis for API request
throttling. The utility supports both middleware-level and route-level
rate limiting with configurable fixed window limits (100 requests per 10s).

Includes comprehensive usage examples for Next.js middleware and API routes,
complete with response headers for rate limit status and proper error handling
for 429 responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API rate limiting with a threshold of 100 requests per 10-second window. Rate limit status is communicated via HTTP headers, with a 429 response when the limit is exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->