### PR TITLE
style(docs): adjust max-width for architecture tabs component

### DIFF
--- a/apps/web/src/components/docs/architecture-tabs.tsx
+++ b/apps/web/src/components/docs/architecture-tabs.tsx
@@ -50,7 +50,7 @@ export default function ArchitectureTabs({
   return (
     <div
       className={cn(
-        "bg-background text-muted-primary my-3 w-full overflow-auto rounded-md sm:max-w-full",
+        "bg-background text-muted-primary my-3 w-full overflow-auto rounded-md sm:max-w-200",
         availableArchs.length === 2 && "border",
         className
       )}>


### PR DESCRIPTION
- Update max-width from `sm:max-w-full` to `sm:max-w-200` for improved layout consistency
- Enhance responsiveness of the architecture tabs in documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the responsive width behavior of the architecture tabs component to improve its layout display on small screens and smaller viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->