### PR TITLE
feat(email-service): add support for Nodemailer and Resend providers

### DIFF
--- a/packages/registry/component/email-service.json
+++ b/packages/registry/component/email-service.json
@@ -48,6 +48,38 @@
               "env": ["MAILTRAP_API_KEY", "EMAIL_FROM"]
             }
           }
+        },
+        "nextjs": {
+          "prompt": "Select an email provider: ",
+          "variants": {
+            "nodemailer": {
+              "label": "Nodemailer (SMTP)",
+              "templates": {
+                "file-api": "email-service/nodemailer/file-api"
+              },
+              "dependencies": {
+                "runtime": ["nodemailer", "zod"],
+                "dev": ["@types/nodemailer"]
+              },
+              "env": [
+                "SMTP_HOST",
+                "SMTP_PORT",
+                "SMTP_USER",
+                "SMTP_PASS",
+                "EMAIL_FROM"
+              ]
+            },
+            "resend": {
+              "label": "Resend",
+              "templates": {
+                "file-api": "email-service/resend/file-api"
+              },
+              "dependencies": {
+                "runtime": ["resend", "zod"]
+              },
+              "env": ["RESEND_API_KEY", "EMAIL_FROM"]
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
- Introduced new email provider options in the email service configuration.
- Added Nodemailer with SMTP settings and required environment variables.
- Included Resend provider with its own templates and dependencies.
- Enhanced flexibility for email service integration in Next.js applications.