### PR TITLE
feat/copy file path

### DIFF
--- a/apps/web/src/components/file-viewer/file-tree.tsx
+++ b/apps/web/src/components/file-viewer/file-tree.tsx
@@ -4,9 +4,6 @@ import * as React from "react";
 import {
   ChevronDown,
   ChevronRight,
-  File,
-  Folder,
-  FolderOpenIcon
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getIconForLanguageExtension } from "@/components/docs/icons/language-icons";
@@ -14,16 +11,18 @@ import { FaFolder, FaFolderOpen } from "react-icons/fa6";
 
 export type FileNode =
   | {
-      type: "folder";
-      name: string;
-      children: FileNode[];
-    }
+    path?: string;
+    type: "folder";
+    name: string;
+    children: FileNode[];
+  }
   | {
-      type: "file";
-      name: string;
-      content: string;
-      lang?: string;
-    };
+    path?: string;
+    type: "file";
+    name: string;
+    content: string;
+    lang?: string;
+  };
 
 type Props = {
   data: FileNode[];
@@ -90,7 +89,7 @@ function TreeNode({
       className={cn(
         "text-muted-foreground hover:bg-muted hover:text-accent-foreground my-1 ml-0.5 flex w-auto cursor-pointer items-center gap-2 rounded-md px-2 py-1 border border-transparent hover:border-edge text-left",
         activeFile === node.name &&
-          "bg-muted text-accent-foreground border-edge"
+        "bg-muted text-accent-foreground border-edge"
       )}>
       {getIconForLanguageExtension(node.lang || "ts", node.name)}
       {node.name}

--- a/apps/web/src/components/file-viewer/index.tsx
+++ b/apps/web/src/components/file-viewer/index.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import FileTree, { type FileNode } from "@/components/file-viewer/file-tree";
-import { getRegistryFileTree } from "@/lib/files";
+import { addPaths, getRegistryFileTree } from "@/lib/files";
 import { useCodeTheme } from "@/store/use-code-theme";
 import { highlightCode } from "@/app/actions/highlight";
 import {
@@ -11,6 +11,7 @@ import {
   ResizablePanelGroup
 } from "@/components/ui/resizable";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
+
 import CopyButton from "@/components/docs/copy-button";
 import { cn } from "@/lib/utils";
 import { getIconForLanguageExtension } from "@/components/docs/icons/language-icons";
@@ -50,7 +51,9 @@ export default function ComponentFileViewer({
   >(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
-  const { copied, copy } = useCopyToClipboard();
+  const { copied: copiedContent, copy: copyContent } = useCopyToClipboard();
+  const { copied: copiedPath, copy: copyPath } = useCopyToClipboard();
+  const [path, setPath] = React.useState<string>("");
   const { theme } = useCodeTheme();
 
   const { variant } = useVariant();
@@ -75,12 +78,14 @@ export default function ComponentFileViewer({
           variant: variant ?? undefined
         });
         // console.log({ fileTree });
-        setTree(fileTree.tree);
+        const treeWithPaths = addPaths(fileTree.tree);
+        setTree(treeWithPaths);
         // auto-select first file
-        const firstFile = findFirstFile(fileTree.tree);
+        const firstFile = findFirstFile(treeWithPaths);
         if (firstFile) {
           setSelectedFile(firstFile);
           setActiveFile(firstFile.name);
+          setPath(firstFile.path || "");
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : "Something went wrong");
@@ -113,17 +118,29 @@ export default function ComponentFileViewer({
   function handleSelect(file: FileNode & { type: "file" }) {
     setSelectedFile(file);
     setActiveFile(file.name);
+    setPath(file.path || "");
   }
 
   async function handleCopy() {
     if (!selectedFile?.content) return;
 
     try {
-      await copy(selectedFile.content);
+      await copyContent(selectedFile.content);
     } catch (error) {
       console.error("Failed to copy file content:", error);
     }
   }
+
+  async function handleFilePathCopy() {
+    if (!path) return;
+
+    try {
+      await copyPath(path);
+    } catch (error) {
+      console.error("Failed to copy file path:", error);
+    }
+  }
+
 
   if (loading) return <div className="p-4">Loading files...</div>;
   if (error) return <div className="p-4 text-red-500">{error}</div>;
@@ -161,16 +178,27 @@ export default function ComponentFileViewer({
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize="65%">
           <div className="relative flex items-center justify-between border-b">
-            <div className="text-muted-foreground font-code flex items-center gap-1 px-2 py-2 text-[15px]">
-              {getIconForLanguageExtension(
-                selectedFile?.lang || "ts",
-                selectedFile?.name
-              )}{" "}
-              {selectedFile?.name || "No file selected"}
+            <div className="group relative">
+              <div className="text-muted-foreground font-code flex items-center gap-1 px-2 py-2 text-[15px]">
+                {getIconForLanguageExtension(
+                  selectedFile?.lang || "ts",
+                  selectedFile?.name
+                )}{" "}
+                {selectedFile?.name || "No file selected"}
+              </div>
+
+              <CopyButton
+                handleCopy={handleFilePathCopy}
+                copied={copiedPath}
+                className={cn(
+                  "bg-code opacity-0 group-hover:opacity-100 absolute -right-8 top-1/2 -translate-y-1/2 z-20 flex items-center justify-center transition-all",
+                  selectedFile?.name ? "cursor-pointer" : "cursor-not-allowed"
+                )}
+              />
             </div>
             <CopyButton
               handleCopy={handleCopy}
-              copied={copied}
+              copied={copiedContent}
               className={cn(
                 "bg-code absolute right-2 z-20 flex items-center justify-center transition-all",
                 selectedFile?.content ? "cursor-pointer" : "cursor-not-allowed"

--- a/apps/web/src/content/docs/express/blueprints/hybrid-auth-mongodb.mdx
+++ b/apps/web/src/content/docs/express/blueprints/hybrid-auth-mongodb.mdx
@@ -4,7 +4,7 @@ description: Hybrid authentication with MongoDB, Mongoose, and Redis-backed sess
 command: npx servercn-cli add bp hybrid-auth
 contributor:
  -  name: Akkal Dhami
-    url: https://www.akkaldhami.com.np
+    url: https://github.com/akkaldhami
     avatar: https://avatars.githubusercontent.com/u/170957638?v=4
 ---
 

--- a/apps/web/src/content/docs/express/components/email-service.mdx
+++ b/apps/web/src/content/docs/express/components/email-service.mdx
@@ -2,7 +2,10 @@
 title: Email Service
 description: Production-ready email service for sending emails in Servercn using nodemailer with support for multiple providers (Nodemailer, Resend, Mailtrap, etc.).
 command: npx servercn-cli add email-service
-
+contributor:
+ -  name: Akkal Dhami
+    url: https://www.akkal.com.np
+    avatar: https://avatars.githubusercontent.com/u/170957638?v=4 
 ---
 
 # Email Service

--- a/apps/web/src/lib/files.ts
+++ b/apps/web/src/lib/files.ts
@@ -114,6 +114,30 @@ export function buildFileTree(files: RegistryFile[]): FileNode[] {
   return sortTree(tree);
 }
 
+export function addPaths(
+  nodes: FileNode[],
+  parentPath = ""
+): FileNode[] {
+  return nodes.map((node) => {
+    const currentPath = parentPath
+      ? `${parentPath}/${node.name}`
+      : node.name;
+
+    if (node.type === "folder") {
+      return {
+        ...node,
+        path: currentPath,
+        children: addPaths(node.children, currentPath),
+      };
+    }
+
+    return {
+      ...node,
+      path: currentPath,
+    };
+  });
+}
+
 export async function getRegistryJson<T = unknown>(
   slug: string,
   type: ItemType


### PR DESCRIPTION
- add `addPaths` utility to compute full canonical file paths
- extend FileNode type with optional `path` property
- populate file paths when loading registry file trees
- add path copy button in viewer header alongside content copy
- fix clipboard hook variable naming for clarity
- update file tree icon imports and usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to copy file paths to clipboard in the file viewer component.

* **Documentation**
  * Updated contributor profile links and attribution information in documentation pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkkalDhami/servercn/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->