### PR TITLE
style: adjust container max width and refine tab styles

### DIFF
--- a/apps/web/src/app/(app)/foundations/page.tsx
+++ b/apps/web/src/app/(app)/foundations/page.tsx
@@ -35,7 +35,7 @@ export const generateMetadata = (): Metadata => {
 
 export default function FoundationsPage() {
   return (
-    <Container className="border-edge w-full max-w-360 border-x px-0 pt-16">
+    <Container className="border-edge w-full border-x px-0 pt-16">
       <div className="dark:bg-[radial-gradient(35%_128px_at_0%_0%,--theme(--color-foreground/.08),transparent),radial-gradient(35%_128px_at_100%_0%,--theme(--color-foreground/.08),transparent)] flex justify-between flex-wrap mb-6 px-4 pt-2">
         <div>
           <Heading className="tracking-tight capitalize">

--- a/apps/web/src/components/docs/package-manager-tabs.tsx
+++ b/apps/web/src/components/docs/package-manager-tabs.tsx
@@ -33,7 +33,7 @@ export default function PackageManagerTabs({
   return (
     <Tabs
       value={pkgManager}
-      className={cn("bg-code my-6 rounded-lg sm:max-w-210")}>
+      className={cn("bg-code my-6 border border-neutral-500/10 rounded-lg sm:max-w-210")}>
       <TabsList className={cn("bg-transparent pt-3 pl-3")}>
         <TerminalIcon className="text-muted-foreground mr-3 size-6 pt-1" />
         {Object.keys(managers).map(m => {
@@ -58,7 +58,7 @@ export default function PackageManagerTabs({
         const [bin, ...rest] = cmd.split(" ");
         const remaining = rest.join(" ");
         return (
-          <TabsContent key={key} value={key}>
+          <TabsContent key={key} value={key} className="border-t border-neutral-500/10">
             <CodeWrapper code={cmd}>
               {/* <CodeBlock code={cmd} /> */}
               <pre className="overflow-x-auto overscroll-x-contain p-4">

--- a/apps/web/src/components/ui/container.tsx
+++ b/apps/web/src/components/ui/container.tsx
@@ -15,7 +15,7 @@ export const Container: React.FC<ContainerProps> = ({
 }) => {
   return (
     <section
-      className={cn("container mx-auto w-full max-w-360 px-4 pb-6", className)}
+      className={cn("container mx-auto w-full max-w-368 px-4 pb-6", className)}
       {...props}>
       {children}
     </section>


### PR DESCRIPTION
- update Container component's max-width from 360 to 368
- remove redundant max-w-360 class from foundations page
- add border styling to package manager tabs and their content blocks