### PR TITLE
docs(express/foundations): remove redundant setup overview sections

### DIFF
--- a/apps/web/src/content/docs/express/foundations/drizzle-mysql-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/drizzle-mysql-starter.mdx
@@ -27,34 +27,6 @@ Setting up Drizzle with MySQL repeatedly involves:
 
 The Drizzle MySQL Starter standardizes these concerns using a **minimal, explicit setup**.
 
-## What You Get Out of the Box
-
-After initialization, your project includes:
-
-### Database Core
-
-- Drizzle ORM configured for MySQL
-- Type‑safe schema definitions
-- Centralized database client
-
-### Configuration
-
-- Environment‑based database config
-- Safe startup validation
-- Production‑ready connection handling
-
-### Migrations
-
-- Drizzle migration setup
-- Structured migration folder
-- CLI‑ready workflow
-
-### Developer Experience
-
-- Fully typed queries
-- Clean schema organization
-- Zero runtime magic
-
 ## Environment Configuration
 
 Database credentials are loaded via environment variables.

--- a/apps/web/src/content/docs/express/foundations/drizzle-pg-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/drizzle-pg-starter.mdx
@@ -25,36 +25,6 @@ Setting up Drizzle with PostgreSQL repeatedly involves:
 - Environment-based credentials
 - Type safety across queries
 
-The Drizzle PostgreSQL Starter standardizes these concerns using a **minimal, explicit setup**.
-
-## What You Get Out of the Box
-
-After initialization, your project includes:
-
-### Database Core
-
-- Drizzle ORM configured for PostgreSQL
-- Type-safe schema definitions
-- Centralized database client
-
-### Configuration
-
-- Environment-based database config
-- Safe startup validation
-- Production-ready connection handling
-
-### Migrations
-
-- Drizzle migration setup
-- Structured migration folder
-- CLI-ready workflow
-
-### Developer Experience
-
-- Fully typed queries
-- Clean schema organization
-- Zero runtime magic
-
 ## Environment Configuration
 
 Database credentials are loaded via environment variables.

--- a/apps/web/src/content/docs/express/foundations/mongoose-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/mongoose-starter.mdx
@@ -27,30 +27,6 @@ Setting up Mongoose with MongoDB repeatedly involves:
 - Environment‑based credentials
 - TypeScript integration
 
-The Mongoose Starter standardizes these concerns using a **structured, explicit setup**.
-
-## What You Get Out of the Box
-
-After initialization, your project includes:
-
-### Database Core
-
-- Mongoose configured for MongoDB
-- Typed Schema definitions
-- Centralized database connection logic
-
-### Configuration
-
-- Environment‑based database config
-- Connection event handling (success, error)
-- Production‑ready settings
-
-### Developer Experience
-
-- Type inference from schemas
-- Clean model separation
-- Ready-to-use patterns
-
 ## Environment Configuration
 
 Database credentials are loaded via environment variables.
@@ -147,9 +123,3 @@ export const connectDB = async (): Promise<void> => {
 ```
 
 This setup ensures a robust connection handling strategy, exiting the process on failure to prevent undefined behaviors.
-
-## Summary
-
-The **Mongoose Starter** gives you a clean, production‑ready database foundation using **MongoDB + Mongoose**.
-
-It prioritizes developer experience, schema validation, and rapid iteration — providing a reliable data layer for your Node.js applications.

--- a/apps/web/src/content/docs/express/foundations/prisma-mongodb-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/prisma-mongodb-starter.mdx
@@ -28,36 +28,6 @@ Setting up Prisma with MongoDB repeatedly involves:
 - Environment configuration
 - Query logging and debugging
 
-The Prisma MongoDB Starter standardizes these concerns so every project starts with a **reliable database layer**.
-
-## What You Get Out of the Box
-
-After initialization, your project includes:
-
-### Database Core
-
-- Prisma ORM configured for MongoDB
-- Prisma Client for type-safe queries
-- Centralized database configuration
-
-### Configuration
-
-- Environment‑based database config
-- Safe startup validation
-- Production‑ready connection handling
-
-### Schema Management
-
-- Prisma schema definition 
-- MongoDB models managed via Prisma
-- Type-safe access across the application
-
-### Developer Experience
-
-- Fully typed queries
-- Clean schema organization
-- Zero runtime magic
-
 ## Environment Configuration
 
 Database credentials are loaded via environment variables.

--- a/apps/web/src/content/docs/express/foundations/prisma-mysql-starter.mdx
+++ b/apps/web/src/content/docs/express/foundations/prisma-mysql-starter.mdx
@@ -28,36 +28,6 @@ Setting up Prisma with MySQL repeatedly involves:
 - Environment configuration
 - Query logging and debugging
 
-The Prisma MySQL Starter standardizes these concerns so every project starts with a **reliable database layer**.
-
-## What You Get Out of the Box
-
-After initialization, your project includes:
-
-### Database Core
-
-- Prisma ORM configured for MySQL
-- Prisma Client for type-safe queries
-- Centralized database configuration
-
-### Configuration
-
-- Environment‑based database config
-- Safe startup validation
-- Production‑ready connection handling
-
-### Migrations
-
-- Prisma migration setup
-- Structured migration workflow
-- CLI‑ready <Code>db:migrate</Code> and <Code>db:deploy</Code> scripts
-
-### Developer Experience
-
-- Fully typed queries
-- Clean schema organization
-- Zero runtime magic
-
 ## Environment Configuration
 
 Database credentials are loaded via environment variables.


### PR DESCRIPTION
Clean up the Express database starter documentation, remove duplicated "What You Get Out of the Box" sections across all guides, and delete the extra summary section from the mongoose starter guide to streamline the content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined Express starter guides for Drizzle (MySQL and PostgreSQL), Mongoose, and Prisma (MongoDB and MySQL) by removing intermediate descriptive sections, allowing users to progress quickly to practical configuration steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkkalDhami/servercn/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->