### PR TITLE
docs: add code block titles and fix doc formatting

### DIFF
--- a/apps/web/src/content/docs/nextjs/schemas/todo-mongodb.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/todo-mongodb.mdx
@@ -11,6 +11,7 @@ This page documents the Todo schema for projects using <Code children="MongoDB" 
 
 The Todo schema provides a production-ready model for managing tasks, complete with user validation and performance considerations.
 
+---
 
 ## Installation Guide
 
@@ -18,7 +19,7 @@ To add this schema to your project, run:
 
 <PackageManagerTabs command="npx servercn-cli add sc todo" />
 
-During initialization, ensure you select <Code children="MongoDB" /> when prompted for the database.
+---
 
 ## Database Design
 
@@ -26,14 +27,11 @@ To see the complete database design, including the User schema from the Auth Dom
 
 [Database Design](https://www.drawdb.app/editor?shareId=577068fc81a9a9faba35fa9133dd5392)
 
+---
 
 ## Todo Model
 
-The **Todo Model** stores individual task information and maintains a reference to the user who created it.
-
-<Code children="src/models/todo.model.ts"/>
-
-```ts
+```ts title="src/models/todo.model.ts"
 import mongoose, { Document, Model, Schema, Types } from "mongoose";
 
 /**
@@ -98,11 +96,11 @@ export default Todo;
 
 <PackageManagerTabs command="npx servercn-cli add sc todo/todo" />
 
+---
+
 ## User Model
 
-<Code children="src/models/user.model.ts"/>
-
-```ts
+```ts title="src/models/user.model.ts"
 import mongoose, { Document, Model, Schema } from "mongoose";
 
 export interface IAvatar {
@@ -216,6 +214,8 @@ const User: Model<IUser> =
 export default User;
 ```
 
+---
+
 ## Relationship Reference
 
 The <Code children="userId" /> field uses a reference to the <Code children="User" /> model. When querying todos, you can easily populate user information:
@@ -225,10 +225,3 @@ const userTodos = await Todo.find({ userId: req.user._id })
   .populate("userId", "name email")
   .sort("-createdAt");
 ```
-
-## Key Benefits
-
-- **Strict Validation**: Ensures all todos have a user and a title.
-- **Auto-Timestamps**: Leverages Mongoose's built-in timestamp support.
-- **Optimized Queries**: Includes indexes for common access patterns.
-- **MLean Ready**: Compatible with <Code children=".lean()" /> for faster read operations.

--- a/apps/web/src/content/docs/nextjs/schemas/todo-mysql.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/todo-mysql.mdx
@@ -11,13 +11,15 @@ This page documents the Todo schema for projects using <Code children="MySQL" />
 
 The MySQL implementation focuses on compatibility and performance, using standard types and efficient indexes.
 
+---
+
 ## Installation Guide
 
 To add this schema to your project, run:
 
 <PackageManagerTabs command="npx servercn-cli add sc todo" />
 
-During initialization, ensure you select <Code children="MySQL" /> when prompted for the database.
+---
 
 ## Database Design
 
@@ -27,13 +29,13 @@ To see the complete database design, including the User schema from the Auth Dom
 
 <Note text="If you install schema individually, the relationships between them won't be automatic—you'll need to implement them manually." />
 
+---
+
 ## 1. User Schema
 
 The **User Schema** is the core component for storing user identity, credentials, and profile information.
 
-**File Path:** <Code children="src/db/schemas/user.schema.ts" />
-
-```ts
+```ts title="src/db/schemas/user.schema.ts"
 import {
   mysqlTable,
   varchar,
@@ -101,13 +103,14 @@ export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 ```
 
+---
+
+
 ## 2. Todo Schema
 
 The **Todo Schema** defines the structure of your tasks in MySQL.
 
-**File Path:** <Code children="src/db/schemas/todo.schema.ts"/>  
-
-```ts
+```ts title="src/db/schemas/todo.schema.ts"
 import {
   boolean,
   mysqlTable,
@@ -158,11 +161,11 @@ export type NewTodo = typeof todos.$inferInsert;
 
 <PackageManagerTabs command="npx servercn-cli add sc todo/todo" />
 
+---
+
 ## 3. schema.helper.ts
 
-<Code>src/db/schemas/schema.helper.ts</Code>
-
-```ts
+```ts title="src/db/schemas/schema.helper.ts"
 import { timestamp } from "drizzle-orm/mysql-core";
 
 export const timestamps = {
@@ -171,20 +174,20 @@ export const timestamps = {
 };
 ```
 
+---
+
 ## 4. Export all schemas
 
-<Code>ssrc/db/index.ts</Code>
-
-```ts
+```ts title="src/db/index.ts"
 export * from "./schemas/user.schema";
 export * from "./schemas/todo.schema";
 ```
 
+---
+
 ## 5. drizzle.config.ts
 
-<Code>drizzle.config.ts</Code>
-
-```ts
+```ts title="drizzle.config.ts"
 import { Config, defineConfig } from "drizzle-kit";
 
 export default defineConfig({
@@ -199,12 +202,13 @@ export default defineConfig({
 }) satisfies Config;
 ```
 
+---
+
 ## Relational Design
 
 Explicit relations make data fetching much simpler and more expressive:
 
-<Code>src/db/schemas/user.schema.ts</Code>
-```ts
+```ts title="src/db/schemas/user.schema.ts"
 import { relations } from "drizzle-orm";
 import { todos } from "./todo.schema";
 
@@ -216,9 +220,9 @@ export const usersRelations = relations(users, ({ many }) => ({
 }));
 ```
 <br/>
+---
 
-<Code>src/db/schemas/todo.schema.ts</Code>
-```ts
+```ts title="src/db/schemas/todo.schema.ts"
 import { relations } from "drizzle-orm";
 import { users } from "./user.schema";
 

--- a/apps/web/src/content/docs/nextjs/schemas/todo-postgresql.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/todo-postgresql.mdx
@@ -11,6 +11,7 @@ This page documents the Todo schema for projects using <Code children="PostgreSQ
 
 The PostgreSQL implementation leverages strong types and relational integrity to provide a secure and efficient task management foundation.
 
+---
 
 ## Installation Guide
 
@@ -18,7 +19,7 @@ To add this schema to your project, run:
 
 <PackageManagerTabs command="npx servercn-cli add sc todo" />
 
-During initialization, ensure you select <Code children="PostgreSQL" /> when prompted for the database.
+---
 
 ## Database Design
 
@@ -28,13 +29,13 @@ To see the complete database design, including the User schema from the Auth Dom
 
 <Note text="If you install schema individually, the relationships between them won't be automatic—you'll need to implement them manually." />
 
+---
+
 ## 1. User Schema
 
 The **User Schema** is the core component for storing user identity, credentials, and profile information.
 
-<Code children="src/db/schemas/user.schema.ts" />
-
-```ts
+```ts title="src/db/schemas/user.schema.ts"
 import {
   pgTable,
   serial,
@@ -104,13 +105,13 @@ export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 ```
 
+---
+
 ## 2. Todo Schema
 
 The **Todo Schema** defines the structure of your tasks in PostgreSQL.
 
-<Code children="src/db/schemas/todo.schema.ts" />
-
-```ts
+```ts title="src/db/schemas/todo.schema.ts"
 import {
   boolean,
   text,
@@ -162,11 +163,11 @@ export type NewTodo = typeof todos.$inferInsert;
 
 <PackageManagerTabs command="npx servercn-cli add sc todo/todo" />
 
+---
+
 ## 3. schema.helper.ts
 
-<Code>src/db/schemas/schema.helper.ts</Code>
-
-```ts
+```ts title="src/db/schemas/schema.helper.ts"
 import { timestamp } from "drizzle-orm/pg-core";
 
 export const timestamps = {
@@ -178,20 +179,20 @@ export const timestamps = {
 };
 ```
 
+---
+
 ## 4. Export all schemas
 
-<Code>ssrc/db/index.ts</Code>
-
-```ts
+```ts title="src/db/index.ts"
 export * from "./schemas/user.schema";
 export * from "./schemas/todo.schema";
 ```
 
+---
+
 ## 5. drizzle.config.ts
 
-<Code>drizzle.config.ts</Code>
-
-```ts
+```ts title="drizzle.config.ts"
 import { Config, defineConfig } from "drizzle-kit";
 
 export default defineConfig({
@@ -206,12 +207,13 @@ export default defineConfig({
 }) satisfies Config;
 ```
 
+---
+
 ## Relational Design
 
 Explicit relations make data fetching much simpler and more expressive:
 
-<Code>src/db/schemas/user.schema.ts</Code>
-```ts
+```ts title="src/db/schemas/user.schema.ts"
 import { relations } from "drizzle-orm";
 import { todos } from "./todo.schema";
 
@@ -223,9 +225,9 @@ export const usersRelations = relations(users, ({ many }) => ({
 }));
 ```
 <br/>
+---
 
-<Code>src/db/schemas/todo.schema.ts</Code>
-```ts
+```ts title="src/db/schemas/todo.schema.ts"
 import { relations } from "drizzle-orm";
 import { users } from "./user.schema";
 

--- a/apps/web/src/content/docs/tooling/commitlint.mdx
+++ b/apps/web/src/content/docs/tooling/commitlint.mdx
@@ -45,9 +45,7 @@ It also generates a configuration file:
 
 Below is the default configuration provided by Servercn, with inline explanations for clarity.
 
-<Code children="commitlint.config.ts"/>
-
-```ts
+```ts title="commitlint.config.ts"
 export default {
   /**
    * Extends the official Conventional Commits rule set.

--- a/apps/web/src/content/docs/tooling/eslint.mdx
+++ b/apps/web/src/content/docs/tooling/eslint.mdx
@@ -49,9 +49,7 @@ Servercn provides a **sensible default configuration** focused on backend correc
 
 Below is the canonical configuration with inline explanations.
 
-<Code children="eslint.config.mjs" />
-
-```ts
+```ts title="eslint.config.mjs"
 import tseslint from "@typescript-eslint/eslint-plugin";
 import tsparser from "@typescript-eslint/parser";
 import prettierPlugin from "eslint-plugin-prettier/recommended";
@@ -89,7 +87,7 @@ export default [
 
 Add the following scripts to your <Code children="package.json" /> to standardize linting across environments:
 
-```json {3-4}
+```json title="package.json" {3-4}
 {
   "scripts": {
     "lint:check": "eslint .",

--- a/apps/web/src/content/docs/tooling/lint-staged.mdx
+++ b/apps/web/src/content/docs/tooling/lint-staged.mdx
@@ -23,9 +23,8 @@ The Servercn setup automatically adds a <Code children="lint-staged" />  configu
 You can customize this configuration to match your project’s structure and tooling.
 
 #### Basic Example (TypeScript)
-<Code children="package.json" />
 
-```json {4-12}
+```json title="package.json" {4-12} 
 {
   "scripts": {...},
 
@@ -44,9 +43,8 @@ You can customize this configuration to match your project’s structure and too
 }
 ```
 #### Express + TypeScript Example
-<Code children="package.json" />
 
-```json 
+```json title="package.json"
 {
   "lint-staged":{
     "src/**/*.{ts,tsx}": [
@@ -60,10 +58,8 @@ You can customize this configuration to match your project’s structure and too
 }
 ```
 
-#### With Type Checking (Strict)e
-<Code children="package.json" />
-
-```json
+#### With Type Checking (Strict)
+```json title="package.json" {4-12} 
 {
   "lint-staged":{
     "src/**/*.ts": [
@@ -80,9 +76,7 @@ _**⚠️ Use this with caution on large projects, as type checking may slow dow
 
 Instead of <Code children="package.json" />, you can define your rules in <Code children=".lintstagedrc.json" />:
 
-<Code children=".lintstagedrc.json" />
-
-```json
+```json title=".lintstagedrc.json"
 {
   "*.{js,ts}": [ "eslint --fix", "prettier --write" ],
   "*.{json,md,yml}": "prettier --write"

--- a/apps/web/src/content/docs/tooling/prettier.mdx
+++ b/apps/web/src/content/docs/tooling/prettier.mdx
@@ -20,9 +20,7 @@ Install the Prettier configuration using the Servercn CLI:
 
 The component installs a <Code children=".prettierrc" /> file and a <Code children=".prettierignore" /> file with sensible defaults for backend development.
 
-<Code children=".prettierrc" />
-
-```json
+```json title=".prettierrc"
 {
   "singleQuote": false,
   "semi": true,
@@ -38,7 +36,7 @@ The component installs a <Code children=".prettierrc" /> file and a <Code childr
 
 Add the following scripts to your <Code children="package.json" />:
 
-```json {3-4}
+```json title="package.json" {3-4} 
 {
   "scripts": {
     "format:check": "npx prettier . --check",

--- a/apps/web/src/content/docs/tooling/typescript.mdx
+++ b/apps/web/src/content/docs/tooling/typescript.mdx
@@ -23,7 +23,7 @@ The component provides a <Code children="tsconfig.json" /> file optimized for mo
 <Code children="tsconfig.json" />
 
 ### 1. Minimal
-```json
+```json title="tsconfig.json"
 {
   "compilerOptions": {
     "target": "ES2021",
@@ -49,7 +49,7 @@ The component provides a <Code children="tsconfig.json" /> file optimized for mo
 
 ### 2. Advanced
 
-```json
+```json title="tsconfig.json"
 {
   "compilerOptions": {
     "target": "ES2021",
@@ -96,7 +96,7 @@ The component provides a <Code children="tsconfig.json" /> file optimized for mo
 
 Add the following scripts to your <Code children="package.json" />:
 
-```json {3-6}
+```json title="package.json" {3-6} 
 {
   "scripts": {
     "dev": "tsx watch src/server.ts",
@@ -110,7 +110,7 @@ Add the following scripts to your <Code children="package.json" />:
 
 If you prefer nodemon, add a <Code children="nodemon.json" /> file:
 
-```json
+```json title="nodemon.json"
 {
   "watch": ["src"],
   "ext": "ts",
@@ -120,7 +120,7 @@ If you prefer nodemon, add a <Code children="nodemon.json" /> file:
 
 Then update your scripts:
 
-```json {3-6}
+```json title="package.json" {3-6} 
 {
   "scripts": {
     "dev": "nodemon",


### PR DESCRIPTION
Update all documentation files under apps/web/src/content/docs:
- attach descriptive titles to all markdown code blocks
- remove redundant standalone <Code> components before code snippets
- fix minor typos (such as correcting `ssrc/db` to `src/db` in MySQL schema docs)
- clean up unnecessary section content and line breaks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation formatting across schema guides (MongoDB, MySQL, PostgreSQL) and tooling references (ESLint, Prettier, TypeScript, Commitlint, Lint-staged) by improving code block presentation and structure for better readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkkalDhami/servercn/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->