### PR TITLE
feat(docs): add dotenv language icon support

### DIFF
--- a/apps/web/src/components/docs/icons/language-icons.tsx
+++ b/apps/web/src/components/docs/icons/language-icons.tsx
@@ -646,6 +646,8 @@ export function getIconForLanguageExtension(
       return <LanguageIcons.ts className="fill-foreground size-4" />;
     case "bash":
       return <LanguageIcons.bash className="size-4" />;
+    case "dotenv":
+      return <LanguageIcons.env className="size-4" />;
     case "prisma":
       return <LanguageIcons.prisma className="size-4" />;
     case "sql":

--- a/apps/web/src/components/docs/list-note.tsx
+++ b/apps/web/src/components/docs/list-note.tsx
@@ -11,7 +11,7 @@ export default function LNote({
   return (
     <div
       className={cn(
-        "xsm:max-w[360px] text bg-muted text-primary my-3 flex max-w-[320px] gap-2 border-l-4 border-neutral-500 px-3 py-2 sm:py-2.5 md:max-w-200",
+        "xsm:max-w[360px] text bg-muted text-primary my-3 flex max-w-[320px] gap-2 border-l-4 border-neutral-500 px-3 py-2 sm:py-2.5 md:max-w-300",
         className
       )}>
       {children}

--- a/apps/web/src/components/docs/note.tsx
+++ b/apps/web/src/components/docs/note.tsx
@@ -1,6 +1,6 @@
 export default function Note({ text }: { text: string }) {
   return (
-    <div className="xsm:max-w[360px] text my-3 flex max-w-[320px] gap-2 rounded-lg border border-blue-300 bg-blue-500/10 px-3 py-2 text-blue-500 sm:py-2.5 md:max-w-200 dark:border-blue-900">
+    <div className="xsm:max-w[360px] text my-3 flex max-w-[320px] gap-2 rounded-lg border border-blue-300 bg-blue-500/10 px-3 py-2 text-blue-500 sm:py-2.5 md:max-w-300 dark:border-blue-900">
       <p className="text-base leading-relaxed font-medium tracking-wide">
         {text}
       </p>

--- a/apps/web/src/components/docs/warning.tsx
+++ b/apps/web/src/components/docs/warning.tsx
@@ -1,6 +1,6 @@
 export default function Warning({ text }: { text: string }) {
   return (
-    <div className="xsm:max-w[360px] text my-3 flex max-w-[320px] gap-2 border rounded-lg border-yellow-300 dark:border-yellow-700 bg-yellow-500/10 px-3 py-2 text-yellow-600 sm:py-2.5 md:max-w-200">
+    <div className="xsm:max-w[360px] text my-3 flex max-w-[320px] gap-2 border rounded-lg border-yellow-300 dark:border-yellow-700 bg-yellow-500/10 px-3 py-2 text-yellow-600 sm:py-2.5 md:max-w-300">
       <p className="text-base leading-relaxed font-medium tracking-wide">
         {text}
       </p>


### PR DESCRIPTION
- Add dotenv file extension mapping to the env language icon in language-icons.tsx
- Update md:max-w-200 to md:max-w-300 for LNote, Note and Warning components to improve layout on medium screens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and displaying Dotenv file icons in documentation.

* **Style**
  * Increased responsive width constraints for note and warning components to improve layout spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AkkalDhami/servercn/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->