### PR TITLE
feat(cli): add support for displaying custom messages during add

### DIFF
--- a/packages/cli/src/commands/add/index.ts
+++ b/packages/cli/src/commands/add/index.ts
@@ -27,6 +27,7 @@ import { SERVERCN_URL } from "@/constants/app.constants";
 import { highlighter } from "@/utils/highlighter";
 import { injectEnvSchema } from "@/utils/inject-env-schema";
 import { mapEnvToZod } from "@/utils/env-helpers";
+import { getMessage } from "@/utils/message";
 
 export async function add(registryItemName: string, options: AddOptions = {}) {
   await assertInitialized();
@@ -100,6 +101,16 @@ export async function add(registryItemName: string, options: AddOptions = {}) {
   );
   logger.break();
   logger.log(highlighter.create(`→ Docs: ${docs}`));
+  const message = getMessage({
+    runtime: config.runtime,
+    framework: config.framework,
+    slug: component.slug
+  });
+
+  if (message) {
+    logger.info(message);
+  }
+
   logger.break();
 }
 

--- a/packages/cli/src/types/index.d.ts
+++ b/packages/cli/src/types/index.d.ts
@@ -102,6 +102,7 @@ export interface SimpleFramework {
   architectures?: ArchitectureSet;
   dependencies?: DependencySet;
   env?: EnvSet;
+  message?: string;
 
   // forbidden
   prompt?: never;
@@ -114,6 +115,7 @@ export interface FrameworkVariant {
   architectures?: ArchitectureSet;
   dependencies?: DependencySet;
   env?: EnvSet;
+  message?: string;
 }
 
 export interface VariantFramework {
@@ -125,6 +127,7 @@ export interface VariantFramework {
   templates?: never;
   dependencies?: never;
   env?: never;
+  message?: never;
 }
 
 export type FrameworkConfig = VariantFramework | SimpleFramework;


### PR DESCRIPTION
Add optional `message` field to framework config interfaces, then implement logic to fetch and log custom messages via the getMessage utility when running the add command.