### PR TITLE
eat(nextjs-oauth): add github oauth template

### DIFF
--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/api/auth/[...nextauth]/route.ts
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import { authOptions } from "@/lib/next-auth";
+import NextAuth from "next-auth";
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/globals.css
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/globals.css
@@ -1,0 +1,3 @@
+@import "tailwindcss";
+
+@custom-variant dark (&:is(.dark *));

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/layout.tsx
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
+import "./globals.css";
+import { SessionProvider } from "@/components/providers/session-provider";
+
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"]
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"]
+});
+
+export const metadata: Metadata = {
+  title: "Servercn Next.js GitHub Oauth Component",
+  description: "Next.js GitHub Oauth Component"
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={`${geistSans.variable} ${geistMono.variable} h-full font-sans antialiased`}>
+      <body className="flex min-h-full font-mono flex-col">
+        <SessionProvider>{children}</SessionProvider>
+      </body>
+    </html>
+  );
+}

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/page.tsx
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/page.tsx
@@ -1,0 +1,36 @@
+import { AuthStatus } from "@/components/auth/auth-status";
+import { ProfileCard } from "@/components/auth/profile-card";
+
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <main className="min-h-screen bg-neutral-950 px-6">
+      <div className="relative mx-auto max-w-3xl">
+        <div className="mt-5 flex items-center justify-between rounded-full border border-neutral-500/30 p-4">
+          <Link
+            href="https://github.com/akkaldhami/servercn"
+            target="_blank"
+            className="flex items-center gap-2 rounded-full bg-neutral-50 px-4 py-2 text-sm font-medium text-black">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M12.026 2a9.975 9.975 0 0 0-3.153 19.439c.5.09.679-.217.679-.481c0-.237-.008-.865-.011-1.7c-2.775.6-3.361-1.338-3.361-1.338a2.635 2.635 0 0 0-1.107-1.459c-.9-.619.069-.605.069-.605c.64.088 1.205.467 1.527 1.028a2.124 2.124 0 0 0 2.9.829c.046-.506.272-.979.635-1.334c-2.214-.251-4.542-1.107-4.542-4.93a3.865 3.865 0 0 1 1.026-2.671a3.588 3.588 0 0 1 .1-2.64s.837-.269 2.742 1.021a9.439 9.439 0 0 1 4.992 0c1.906-1.291 2.742-1.021 2.742-1.021c.37.835.405 1.78.1 2.64a3.84 3.84 0 0 1 1.024 2.675c0 3.833-2.33 4.675-4.552 4.922c.48.49.725 1.162.675 1.846c0 1.334-.012 2.41-.012 2.737c0 .267.178.577.687.479A9.975 9.975 0 0 0 12.026 2Z"
+              />
+            </svg>
+            Star on GitHub
+          </Link>
+          <div className="flex items-center justify-center gap-4">
+            <AuthStatus />
+          </div>
+        </div>
+
+        <ProfileCard />
+      </div>
+    </main>
+  );
+}

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/profile/page.tsx
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/profile/page.tsx
@@ -1,0 +1,9 @@
+import { ProfileCard } from "@/components/auth/profile-card";
+
+export default function Page() {
+  return (
+    <div className={"flex h-screen w-full items-center justify-center"}>
+      <ProfileCard />
+    </div>
+  );
+}

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/signin/page.tsx
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/app/signin/page.tsx
@@ -1,0 +1,12 @@
+import { GitHubSignin } from "@/components/auth/github-signin";
+
+export default function Page() {
+  return (
+    <div
+      className={
+        "flex h-screen w-full items-center justify-center bg-neutral-950"
+      }>
+      <GitHubSignin />
+    </div>
+  );
+}

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/components/auth/auth-status.tsx
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/components/auth/auth-status.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { signOut, useSession } from "next-auth/react";
+import Link from "next/link";
+
+export function AuthStatus() {
+  const session = useSession();
+
+  if (session.status !== "authenticated") {
+    return (
+      <Link
+        href="/signin"
+        className="rounded-full border border-neutral-400 bg-neutral-700 px-4 py-2 text-sm font-medium text-neutral-300">
+        Sign In
+      </Link>
+    );
+  }
+
+  return (
+    <button
+      onClick={() => {
+        signOut();
+      }}
+      className="h-10 cursor-pointer rounded-full bg-neutral-50 px-4 font-medium text-black">
+      Sign Out
+    </button>
+  );
+}

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/components/auth/github-signin.tsx
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/components/auth/github-signin.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { signIn, useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
+
+export function GitHubSignin() {
+  const session = useSession();
+
+  if (session.status === "authenticated") {
+    return redirect("/");
+  }
+
+  return (
+    <div className={"mt-4 flex flex-col items-center justify-center"}>
+      <h3 className="text-xl font-medium text-white uppercase">
+        Continue with
+      </h3>
+      <div className="mt-3 w-50">
+        <button
+          className={
+            "relative flex w-full cursor-pointer items-center justify-center gap-5 rounded-full bg-white px-4 py-3"
+          }
+          onClick={() =>
+            signIn("github", {
+              callbackUrl: "/"
+            })
+          }
+          type="button">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            viewBox="0 0 64 64">
+            <path
+              fill="currentColor"
+              d="M32 0C14 0 0 14 0 32c0 21 19 30 22 30c2 0 2-1 2-2v-5c-7 2-10-2-11-5c0 0 0-1-2-3c-1-1-5-3-1-3c3 0 5 4 5 4c3 4 7 3 9 2c0-2 2-4 2-4c-8-1-14-4-14-15q0-6 3-9s-2-4 0-9c0 0 5 0 9 4c3-2 13-2 16 0c4-4 9-4 9-4c2 7 0 9 0 9q3 3 3 9c0 11-7 14-14 15c1 1 2 3 2 6v8c0 1 0 2 2 2c3 0 22-9 22-30C64 14 50 0 32 0"
+            />
+          </svg>
+          GitHub
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/components/auth/profile-card.tsx
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/components/auth/profile-card.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element */
+import { useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
+
+export function ProfileCard() {
+  const session = useSession();
+
+  if (session.status === "loading") {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-8">
+        <div className="flex items-center gap-2">
+          <p className="text-white">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (session.status !== "authenticated") {
+    return redirect("/signin");
+  }
+
+  if (!session.data?.user) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-8">
+        <div className="flex items-center gap-2">
+          <p className="text-white">User not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { user } = session.data;
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-8 text-white">
+      {user.image ? (
+        <img
+          src={user.image}
+          alt={user.name || ""}
+          className="h-24 w-24 rounded-full"
+        />
+      ) : (
+        <div className="flex size-12 items-center justify-center rounded-full bg-neutral-50 text-2xl text-black">
+          {user.name?.charAt(0).toUpperCase()}
+        </div>
+      )}
+
+      <h1 className="text-3xl font-bold">{user.name}</h1>
+      <div className="flex items-center gap-2">
+        <p className="text-neutral-400">{user.email}</p>
+      </div>
+    </div>
+  );
+}
+("use client");
+
+/* eslint-disable @next/next/no-img-element */
+import { useSession } from "next-auth/react";
+import { redirect } from "next/navigation";
+
+export function ProfileCard() {
+  const session = useSession();
+
+  if (session.status === "loading") {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-8">
+        <div className="flex items-center gap-2">
+          <p className="text-white">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (session.status !== "authenticated") {
+    return redirect("/signin");
+  }
+
+  if (!session.data?.user) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-4 py-8">
+        <div className="flex items-center gap-2">
+          <p className="text-white">User not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  const { user } = session.data;
+
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 py-8 text-white">
+      {user.image ? (
+        <img
+          src={user.image}
+          alt={user.name || ""}
+          className="h-24 w-24 rounded-full"
+        />
+      ) : (
+        <div className="flex size-12 items-center justify-center rounded-full bg-neutral-50 text-2xl text-black">
+          {user.name?.charAt(0).toUpperCase()}
+        </div>
+      )}
+
+      <h1 className="text-3xl font-bold">{user.name}</h1>
+      <div className="flex items-center gap-2">
+        <p className="text-neutral-400">{user.email}</p>
+      </div>
+    </div>
+  );
+}

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/components/providers/session-provider.tsx
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/components/providers/session-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { SessionProvider as NextSessionProvider } from "next-auth/react";
+
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextSessionProvider>
+      {children}
+    </NextSessionProvider>
+  );
+}

--- a/packages/templates/node/nextjs/component/oauth/github/file-api/src/lib/next-auth.ts
+++ b/packages/templates/node/nextjs/component/oauth/github/file-api/src/lib/next-auth.ts
@@ -1,0 +1,53 @@
+import { Account, AuthOptions, Profile as NextAuthProfile } from "next-auth";
+import GitHubProvider from "next-auth/providers/github";
+
+interface CustomProfile extends NextAuthProfile {
+  picture?: string;
+  avatar_url?: string;
+  email_verified?: boolean;
+}
+
+export const authOptions: AuthOptions = {
+  callbacks: {
+    async signIn({
+      account,
+      profile
+    }: {
+      account: Account | null;
+      profile?: CustomProfile | undefined;
+    }) {
+      if (!account || !profile) return false;
+      if (account?.provider === "github") {
+        // console.log({ profile, account });
+
+        const userInfo = {
+          name: profile?.name as string,
+          email: profile?.email as string,
+          avatar: profile.picture || profile.avatar_url,
+          provider: account.provider,
+          providerAccountId: account.providerAccountId,
+          isEmailVerified: profile?.email_verified ?? false
+        };
+
+        console.log({ userInfo });
+
+        return true;
+      }
+      return true;
+    }
+  },
+  providers: [
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID as string,
+      clientSecret: process.env.GITHUB_SECRET as string,
+      authorization: {
+        params: {
+          access_type: "offline",
+          response_type: "code"
+        }
+      }
+    })
+  ],
+
+  secret: process.env.NEXTAUTH_SECRET
+};


### PR DESCRIPTION
fadd complete nextjs github oauth authentication setup using nextauth, including route handlers, sign-in and protected profile pages, session provider, auth components, and tailwind css styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Complete GitHub OAuth authentication system with integrated sign-in and sign-out workflows
  * Dedicated user profile page displaying authenticated GitHub account information
  * Session persistence and management across the entire application
  * Automatic redirection to the sign-in page for unauthenticated users
  * Custom authentication verification and user callback functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->