### PR TITLE
fix(docs): exclude step headings from on-this-page sidebar TOC

### DIFF
--- a/apps/web/src/components/docs/mdx-components.tsx
+++ b/apps/web/src/components/docs/mdx-components.tsx
@@ -135,7 +135,7 @@ export const mdxComponents: MDXComponents = {
   Step: ({ className, ...props }: React.ComponentProps<"h3">) => (
     <h3
       className={cn(
-        "mt-3 mb-3 scroll-m-32 text-xl  tracking-tight",
+        "toc-ignore mt-3 mb-3 scroll-m-32 text-xl tracking-tight",
         className
       )}
       {...props}

--- a/apps/web/src/components/docs/on-this-page.tsx
+++ b/apps/web/src/components/docs/on-this-page.tsx
@@ -35,8 +35,8 @@ export function OnThisPage() {
 
       const slugger = new GithubSlugger();
 
-      const elements = Array.from(
-        container.querySelectorAll("h2, h3")
+      const elements = Array.from(container.querySelectorAll("h2, h3")).filter(
+        el => !el.classList.contains("toc-ignore")
       ) as HTMLHeadingElement[];
 
       const list: Heading[] = elements


### PR DESCRIPTION
add toc-ignore class to Step component h3, and update TOC generation to filter out elements with this class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Fixed formatting inconsistency in component styling.

* **New Features**
  * Documentation navigation now supports excluding specific content sections from the "On This Page" sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->