### PR TITLE
feat(next-auth): add github oauth provider support

### DIFF
--- a/packages/templates/node/nextjs/component/oauth/google-github/file-api/src/lib/next-auth.ts
+++ b/packages/templates/node/nextjs/component/oauth/google-github/file-api/src/lib/next-auth.ts
@@ -1,5 +1,6 @@
 import { Account, AuthOptions, Profile as NextAuthProfile } from "next-auth";
 import Google from "next-auth/providers/google";
+import GitHubProvider from "next-auth/providers/github";
 
 interface CustomProfile extends NextAuthProfile {
   picture?: string;
@@ -17,8 +18,8 @@ export const authOptions: AuthOptions = {
       profile?: CustomProfile | undefined;
     }) {
       if (!account || !profile) return false;
-      if (account?.provider === "google") {
-        // console.log({ profile, account });
+      if (account?.provider === "google" || account?.provider === "github") {
+        console.log({ profile, account });
 
         const userInfo = {
           name: profile?.name as string,
@@ -48,7 +49,16 @@ export const authOptions: AuthOptions = {
         }
       }
     }),
-    
+    GitHubProvider({
+      clientId: process.env.GITHUB_ID as string,
+      clientSecret: process.env.GITHUB_SECRET as string,
+      authorization: {
+        params: {
+          access_type: "offline",
+          response_type: "code"
+        }
+      }
+    })
   ],
 
   secret: process.env.NEXTAUTH_SECRET


### PR DESCRIPTION
update the sign-in callback to handle both google and github authentication flows, add debug logging for auth profile and account data, and fix the missing trailing newline in the file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added GitHub OAuth as an authentication method, enabling users to sign in with their GitHub account alongside existing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->