### PR TITLE
docs: update all cli command examples to use @latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,17 @@ npx servercn-cli init
 Add specific modules to your existing project. This allows for incremental adoption.
 
 ```bash
-npx servercn-cli add [component-name]
+npx servercn-cli@latest add [component-name]
 ```
 
 Examples:
 
 ```bash
-npx servercn-cli add logger
+npx servercn-cli@latest add logger
 ```
 
 ```bash
-npx servercn-cli add oauth
+npx servercn-cli@latest add oauth
 ```
 
 ## Components
@@ -49,55 +49,55 @@ npx servercn-cli add oauth
 - ### API Error Handler
 
 ```bash
-npx servercn-cli add error-handler
+npx servercn-cli@latest add error-handler
 ```
 
 - ### API Response Formatter
 
 ```bash
-npx servercn-cli add response-formatter
+npx servercn-cli@latest add response-formatter
 ```
 
 - ### Async Handler
 
 ```bash
-npx servercn-cli add async-handler
+npx servercn-cli@latest add async-handler
 ```
 
 - ### File Upload provider
 
 ```bash
-npx servercn-cli add file-upload
+npx servercn-cli@latest add file-upload
 ```
 
 - ### JWT Utils
 
 ```bash
-npx servercn-cli add jwt-utils
+npx servercn-cli@latest add jwt-utils
 ```
 
 - ### Logger
 
 ```bash
-npx servercn-cli add logger
+npx servercn-cli@latest add logger
 ```
 
 - ### Rate Limiter
 
 ```bash
-npx servercn-cli add rate-limiter
+npx servercn-cli@latest add rate-limiter
 ```
 
 - ### OAuth Provider
 
 ```bash
-npx servercn-cli add oauth
+npx servercn-cli@latest add oauth
 ```
 
 - ### Health Check
 
 ```bash
-npx servercn-cli add health-check
+npx servercn-cli@latest add health-check
 ```
 
 ### And more

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -31,17 +31,17 @@ npx servercn-cli init
 Add specific modules to your existing project. This allows for incremental adoption.
 
 ```bash
-npx servercn-cli add [component-name]
+npx servercn-cli@latest add [component-name]
 ```
 
 Examples:
 
 ```bash
-npx servercn-cli add logger
+npx servercn-cli@latest add logger
 ```
 
 ```bash
-npx servercn-cli add oauth
+npx servercn-cli@latest add oauth
 ```
 
 ## Components
@@ -49,55 +49,55 @@ npx servercn-cli add oauth
 - ### API Error Handler
 
 ```bash
-npx servercn-cli add error-handler
+npx servercn-cli@latest add error-handler
 ```
 
 - ### API Response Formatter
 
 ```bash
-npx servercn-cli add response-formatter
+npx servercn-cli@latest add response-formatter
 ```
 
 - ### Async Handler
 
 ```bash
-npx servercn-cli add async-handler
+npx servercn-cli@latest add async-handler
 ```
 
 - ### File Upload provider
 
 ```bash
-npx servercn-cli add file-upload
+npx servercn-cli@latest add file-upload
 ```
 
 - ### JWT Utils
 
 ```bash
-npx servercn-cli add jwt-utils
+npx servercn-cli@latest add jwt-utils
 ```
 
 - ### Logger
 
 ```bash
-npx servercn-cli add logger
+npx servercn-cli@latest add logger
 ```
 
 - ### Rate Limiter
 
 ```bash
-npx servercn-cli add rate-limiter
+npx servercn-cli@latest add rate-limiter
 ```
 
 - ### OAuth Provider
 
 ```bash
-npx servercn-cli add oauth
+npx servercn-cli@latest add oauth
 ```
 
 - ### Health Check
 
 ```bash
-npx servercn-cli add health-check
+npx servercn-cli@latest add health-check
 ```
 
 ### And more

--- a/apps/web/src/components/command/install-component-command.tsx
+++ b/apps/web/src/components/command/install-component-command.tsx
@@ -10,10 +10,10 @@ export default function InstallComponentCommands({
   return (
     <div className={cn("h-full", className)}>
       <Terminal
-        command="npx servercn-cli add oauth"
+        command="npx servercn-cli@latest add oauth"
         containerClassName={cn("min-h-140")}
         commands={[
-          "npx servercn-cli add oauth",
+          "npx servercn-cli@latest add oauth",
           "? Select OAuth provider:\n> Google\n  GitHub"
         ]}
         outputs={{

--- a/apps/web/src/components/home/hybrid-auth.tsx
+++ b/apps/web/src/components/home/hybrid-auth.tsx
@@ -20,9 +20,9 @@ export default function HybridAuthSection() {
       <div className="grid gap-8 md:grid-cols-1 lg:grid-cols-5">
         <div className="col-span-2 h-full min-h-144">
           <Terminal
-            command="npx servercn-cli add bp hybrid-auth"
+            command="npx servercn-cli@latest add bp hybrid-auth"
             containerClassName={cn("min-h-144 h-full")}
-            commands={["npx servercn-cli add bp hybrid-auth"]}
+            commands={["npx servercn-cli@latest add bp hybrid-auth"]}
             outputs={{
               0: [
                 "CREATE: src/services/otp.service.ts",

--- a/apps/web/src/content/docs/cli/commands.mdx
+++ b/apps/web/src/content/docs/cli/commands.mdx
@@ -50,8 +50,8 @@ Again, you will be prompted to configure your stack:
 Servercn initialized successfully.
 
 You may now add components by running:
-1. npx servercn-cli add <component>
-ex: npx servercn-cli add jwt-utils error-handler http-status-codes
+1. npx servercn-cli@latest add <component>
+ex: npx servercn-cli@latest add jwt-utils error-handler http-status-codes
 ```
 
 This generates a <Code>servercn.config.json</Code> file in your project root:
@@ -131,11 +131,11 @@ It reads your <Code>servercn.config.json</Code> and resolves the correct impleme
 
 Use this to install reusable components such as utilities, middleware, or shared modules.
 
-<PackageManagerTabs command="npx servercn-cli add <component-name>" />
+<PackageManagerTabs command="npx servercn-cli@latest add <component-name>" />
 
 **Example:**
 
-<PackageManagerTabs command="npx servercn-cli add jwt-utils" />
+<PackageManagerTabs command="npx servercn-cli@latest add jwt-utils" />
 
 ---
 
@@ -143,9 +143,9 @@ Use this to install reusable components such as utilities, middleware, or shared
 
 Install development tooling such as linters, formatters, logging utilities, or build integrations.
 
-<PackageManagerTabs command="npx servercn-cli add tooling <tooling-name>" />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling <tooling-name>" />
 
-<PackageManagerTabs command="npx servercn-cli add tl prettier" />
+<PackageManagerTabs command="npx servercn-cli@latest add tl prettier" />
 
 Tooling is configured to match your runtime and language setup.
 
@@ -155,9 +155,9 @@ Tooling is configured to match your runtime and language setup.
 
 Install a predefined feature structure that scaffolds a complete module pattern (routes, controller, service, model).
 
-<PackageManagerTabs command="npx servercn-cli add blueprint <blueprint-name>" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint <blueprint-name>" />
 
-<PackageManagerTabs command="npx servercn-cli add bp stateless-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add bp stateless-auth" />
 
 Blueprints accelerate feature-level development while preserving architectural consistency.
 
@@ -167,9 +167,9 @@ Blueprints accelerate feature-level development while preserving architectural c
 
 Install a provider integration for external services, databases.
 
-<PackageManagerTabs command="npx servercn-cli add pr <provider-name>" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr <provider-name>" />
 
-<PackageManagerTabs command="npx servercn-cli add pr mongodb-prisma" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr mongodb-prisma" />
 
 ---
 
@@ -177,9 +177,9 @@ Install a provider integration for external services, databases.
 
 Install a predefined database schema aligned with your selected database and ORM.
 
-<PackageManagerTabs command="npx servercn-cli add schema <schema-name>" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema <schema-name>" />
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/user" />
 
 The schema is generated based on your configured database type and ORM.
 
@@ -205,20 +205,20 @@ Aliases:
   pr → provider
 
 Commands:
-  $ npx servercn-cli add <component-name>
+  $ npx servercn-cli@latest add <component-name>
   $ npx servercn-cli init <foundation-name>
-  $ npx servercn-cli add tooling <tooling-name>
-  $ npx servercn-cli add pr <provider-name>
-  $ npx servercn-cli add sc <schema-name>
-  $ npx servercn-cli add bp <blueprint-name>
+  $ npx servercn-cli@latest add tooling <tooling-name>
+  $ npx servercn-cli@latest add pr <provider-name>
+  $ npx servercn-cli@latest add sc <schema-name>
+  $ npx servercn-cli@latest add bp <blueprint-name>
 
 Examples:
-  $ npx servercn-cli add oauth
+  $ npx servercn-cli@latest add oauth
   $ npx servercn-cli init express-starter
-  $ npx servercn-cli add tl prettier
-  $ npx servercn-cli add pr mongodb-prisma
-  $ npx servercn-cli add sc auth
-  $ npx servercn-cli add bp stateless-auth
+  $ npx servercn-cli@latest add tl prettier
+  $ npx servercn-cli@latest add pr mongodb-prisma
+  $ npx servercn-cli@latest add sc auth
+  $ npx servercn-cli@latest add bp stateless-auth
 ```  
 
 ---
@@ -358,7 +358,7 @@ Inspect details of a registry item such as a component, blueprint, provider, or 
 {
   "type": "component",
   "slug": "async-handler",
-  "installation": "npx servercn-cli add async-handler",
+  "installation": "npx servercn-cli@latest add async-handler",
   "runtime": "node",
   "framework": "express",
   "architecture": [
@@ -384,7 +384,7 @@ Inspect details of a registry item such as a component, blueprint, provider, or 
 {
   "type": "component",
   "slug": "oauth",
-  "installation": "npx servercn-cli add oauth",
+  "installation": "npx servercn-cli@latest add oauth",
   "runtime": "node",
   "framework": "express",
   "architecture": "mvc",

--- a/apps/web/src/content/docs/cli/overview.mdx
+++ b/apps/web/src/content/docs/cli/overview.mdx
@@ -61,8 +61,8 @@ Again, you will be prompted to configure your stack:
 Servercn initialized successfully.
 
 You may now add components by running:
-1. npx servercn-cli add <component>
-ex: npx servercn-cli add jwt-utils error-handler http-status-codes
+1. npx servercn-cli@latest add <component>
+ex: npx servercn-cli@latest add jwt-utils error-handler http-status-codes
 ```
 
 This generates a <Code>servercn.config.json</Code> file in your project root:

--- a/apps/web/src/content/docs/contributing/blueprint.mdx
+++ b/apps/web/src/content/docs/contributing/blueprint.mdx
@@ -121,7 +121,7 @@ Ensure your templates:
 npm run dev:cli
 ```
 
-<PackageManagerTabs command="npx servercn-cli add bp blueprint-name --local" />
+<PackageManagerTabs command="npx servercn-cli@latest add bp blueprint-name --local" />
 
 - <Code>--local</Code>: Used for testing in the local environment.
 

--- a/apps/web/src/content/docs/contributing/component.mdx
+++ b/apps/web/src/content/docs/contributing/component.mdx
@@ -134,7 +134,7 @@ Each component must follow the registry structure:
 - Must be kebab-case.
 - Used internally by CLI commands:
 
-<PackageManagerTabs command="npx servercn-cli add test-component" />
+<PackageManagerTabs command="npx servercn-cli@latest add test-component" />
 
 ```json
 {
@@ -330,7 +330,7 @@ packages/
 npm run dev:cli
 ```
 
-<PackageManagerTabs command="npx servercn-cli add test-component --local" />
+<PackageManagerTabs command="npx servercn-cli@latest add test-component --local" />
 
 - <Code>--local</Code>: Used for testing in the local environment.
 

--- a/apps/web/src/content/docs/contributing/foundation.mdx
+++ b/apps/web/src/content/docs/contributing/foundation.mdx
@@ -158,7 +158,7 @@ packages/
 npm run dev:cli
 ```
 
-<PackageManagerTabs command="npx servercn-cli add fd foundation-name --local" />
+<PackageManagerTabs command="npx servercn-cli@latest add fd foundation-name --local" />
 
 - <Code>--local</Code>: Used for testing in the local environment.
 

--- a/apps/web/src/content/docs/contributing/provider.mdx
+++ b/apps/web/src/content/docs/contributing/provider.mdx
@@ -140,7 +140,7 @@ npm run dev:cli
 
 Then test provider installation locally:
 
-<PackageManagerTabs command="npx servercn-cli add pr provider-slug --local" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr provider-slug --local" />
 
 - <Code>--local</Code> uses local registry/templates for validation.
 

--- a/apps/web/src/content/docs/contributing/schema.mdx
+++ b/apps/web/src/content/docs/contributing/schema.mdx
@@ -121,7 +121,7 @@ The example below references the registry structure for a schema:
 - Must be kebab-case.
 - Used internally by CLI commands:
 
-<PackageManagerTabs command="npx servercn-cli add sc my-schema" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc my-schema" />
 
 ##### III. templates (Sub-items)
 
@@ -165,7 +165,7 @@ Ensure your templates:
 npm run dev:cli
 ```
 
-<PackageManagerTabs command="npx servercn-cli add sc schema-name --local" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc schema-name --local" />
 
 - <Code>--local</Code>: Used for testing in the local environment.
 

--- a/apps/web/src/content/docs/express/blueprints/banking-app-mongodb.mdx
+++ b/apps/web/src/content/docs/express/blueprints/banking-app-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Banking App with MongoDB
 description: Complete guide to using the Banking Application blueprint with MongoDB and Mongoose, including schema design and database operations
-command: npx servercn-cli add bp banking-app
+command: npx servercn-cli@latest add bp banking-app
 ---
 
 # Banking Application with MongoDB (Mongoose)
@@ -14,7 +14,7 @@ The MongoDB version of the banking app uses **Mongoose** for schema validation, 
 
 ## Installation
 
-<PackageManagerTabs command="npx servercn-cli add bp banking-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add bp banking-app" />
 
 ---
 

--- a/apps/web/src/content/docs/express/blueprints/banking-app.mdx
+++ b/apps/web/src/content/docs/express/blueprints/banking-app.mdx
@@ -2,7 +2,7 @@
 title: Banking Application Blueprint
 description: A production-ready banking application blueprint with MongoDB and Mongoose featuring accounts, transactions, and ledger management
 
-command: npx servercn-cli add bp banking-app
+command: npx servercn-cli@latest add bp banking-app
 ---
 
 # Banking Application Blueprint
@@ -55,7 +55,7 @@ A fully functional banking API with:
 
 Generate a new banking app project using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add blueprint banking-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint banking-app" />
 
 This will create a complete banking application with all the necessary modules, models, and routes.
 

--- a/apps/web/src/content/docs/express/blueprints/hybrid-auth-mongodb.mdx
+++ b/apps/web/src/content/docs/express/blueprints/hybrid-auth-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hybrid Auth | MongoDB (Mongoose)
 description: Hybrid authentication with MongoDB, Mongoose, and Redis-backed sessions.
-command: npx servercn-cli add bp hybrid-auth
+command: npx servercn-cli@latest add bp hybrid-auth
 contributor:
  -  name: Akkal Dhami
     url: https://github.com/akkaldhami
@@ -16,7 +16,7 @@ MongoDB implementation of hybrid authentication using Mongoose for users and Red
 
 Add the hybrid authentication blueprint using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add blueprint hybrid-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint hybrid-auth" />
 
 ## API Endpoints
 

--- a/apps/web/src/content/docs/express/blueprints/hybrid-auth-postgresql.mdx
+++ b/apps/web/src/content/docs/express/blueprints/hybrid-auth-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hybrid Auth | PostgreSQL (Drizzle)
 description: Hybrid authentication with PostgreSQL, Drizzle ORM, and Redis-backed sessions.
-command: npx servercn-cli add bp hybrid-auth
+command: npx servercn-cli@latest add bp hybrid-auth
 contributor:
  -  name: Johnvessly Alti
     url: https://github.com/johnvesslyalti
@@ -16,7 +16,7 @@ PostgreSQL implementation of hybrid authentication using Drizzle ORM for users a
 
 Add the hybrid authentication blueprint using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add blueprint hybrid-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint hybrid-auth" />
 
 ## Key Features
 

--- a/apps/web/src/content/docs/express/blueprints/hybrid-auth.mdx
+++ b/apps/web/src/content/docs/express/blueprints/hybrid-auth.mdx
@@ -1,7 +1,7 @@
 ---
 title: Hybrid Authentication Blueprint
 description: Hybrid auth blueprint combining JWT access tokens with server-tracked sessions, plus OAuth providers.
-command: npx servercn-cli add bp hybrid-auth
+command: npx servercn-cli@latest add bp hybrid-auth
 ---
 
 # Hybrid Authentication Blueprint
@@ -14,7 +14,7 @@ This blueprint ships with credential-based login, OAuth providers, refresh-token
 
 Add the hybrid authentication blueprint using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add blueprint hybrid-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint hybrid-auth" />
 
 ## Features
 

--- a/apps/web/src/content/docs/express/blueprints/stateful-auth-mongodb.mdx
+++ b/apps/web/src/content/docs/express/blueprints/stateful-auth-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Stateful Auth with MongoDB (Mongoose)
 description: Session-based authentication using MongoDB and Mongoose with server-managed sessions.
-command: npx servercn-cli add bp stateful-auth
+command: npx servercn-cli@latest add bp stateful-auth
 ---
 
 # Stateful Authentication with MongoDB (Mongoose)
@@ -12,7 +12,7 @@ MongoDB implementation of stateful authentication using Mongoose ODM for session
 
 You can add the stateful authentication blueprint to your project using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add blueprint stateful-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint stateful-auth" />
 
 ## API Endpoints
 

--- a/apps/web/src/content/docs/express/blueprints/stateful-auth.mdx
+++ b/apps/web/src/content/docs/express/blueprints/stateful-auth.mdx
@@ -2,7 +2,7 @@
 title: Stateful Authentication Blueprint
 description: Session-based authentication blueprint with secure login, logout, and server-managed session flow.
 
-command: npx servercn-cli add bp stateful-auth
+command: npx servercn-cli@latest add bp stateful-auth
 ---
 
 # Stateful Authentication Blueprint
@@ -15,7 +15,7 @@ A comprehensive stateful authentication system using server-side sessions stored
 
 You can add the stateful authentication blueprint to your project using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add blueprint stateful-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint stateful-auth" />
 
 
 ## Features

--- a/apps/web/src/content/docs/express/blueprints/stateless-auth-mongodb.mdx
+++ b/apps/web/src/content/docs/express/blueprints/stateless-auth-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Stateless Auth | MongoDB (Mongoose)
 description: Production-ready stateless authentication implementation using Express, MongoDB, and Mongoose.
-command: npx servercn-cli add blueprint stateless-auth
+command: npx servercn-cli@latest add blueprint stateless-auth
 ---
 
 # Stateless Auth with MongoDB (Mongoose)
@@ -10,7 +10,7 @@ This blueprint provides a complete stateless authentication system for **Express
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add blueprint stateless-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint stateless-auth" />
 
 During installation, select <Code children="MongoDB (Mongoose)" /> as your database.
 

--- a/apps/web/src/content/docs/express/blueprints/stateless-auth-mysql.mdx
+++ b/apps/web/src/content/docs/express/blueprints/stateless-auth-mysql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Stateless Auth | MySQL (Drizzle)
 description: Production-ready stateless authentication implementation using Express, MySQL, and Drizzle ORM.
-command: npx servercn-cli add blueprint stateless-auth
+command: npx servercn-cli@latest add blueprint stateless-auth
 ---
 
 # Stateless Auth with MySQL (Drizzle)
@@ -10,7 +10,7 @@ This blueprint provides a complete stateless authentication system for **Express
 
 ## Installation
 
-<PackageManagerTabs command="npx servercn-cli add blueprint stateless-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint stateless-auth" />
 
 During installation, select **MySQL (Drizzle)** as your database.
 

--- a/apps/web/src/content/docs/express/blueprints/stateless-auth.mdx
+++ b/apps/web/src/content/docs/express/blueprints/stateless-auth.mdx
@@ -1,7 +1,7 @@
 ---
 title: Stateless Authentication
 description: A comprehensive guide to implementing stateless authentication using JWT, Refresh Tokens, and rotation strategies with Express and multiple databases.
-command: npx servercn-cli add blueprint stateless-auth
+command: npx servercn-cli@latest add blueprint stateless-auth
 ---
 
 # Stateless Authentication
@@ -21,7 +21,7 @@ This blueprint provides a production-ready implementation of stateless authentic
 
 You can add the stateless authentication blueprint to your project using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add blueprint stateless-auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add blueprint stateless-auth" />
 
 During installation, you will be prompted to choose:
 

--- a/apps/web/src/content/docs/express/components/async-handler.mdx
+++ b/apps/web/src/content/docs/express/components/async-handler.mdx
@@ -1,7 +1,7 @@
 ---
 title: Async Handler
 description: A lightweight async error-handling wrapper for Express route handlers.
-command: npx servercn-cli add async-handler
+command: npx servercn-cli@latest add async-handler
 
 ---
 
@@ -15,7 +15,7 @@ The <Code>Async Handler</Code> component is a **foundational Express utility** t
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add async-handler" />
+<PackageManagerTabs command="npx servercn-cli@latest add async-handler" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/cron-job.mdx
+++ b/apps/web/src/content/docs/express/components/cron-job.mdx
@@ -1,7 +1,7 @@
 ---
 title: Background Jobs (Cron)
 description: Schedule and manage recurring tasks and background jobs in your Express application using node-cron.
-command: npx servercn-cli add cron-job
+command: npx servercn-cli@latest add cron-job
 
 ---
 
@@ -17,7 +17,7 @@ The **Background Jobs** component provides a standardized way to schedule and ma
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add cron-job" />
+<PackageManagerTabs command="npx servercn-cli@latest add cron-job" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/email-service.mdx
+++ b/apps/web/src/content/docs/express/components/email-service.mdx
@@ -1,7 +1,7 @@
 ---
 title: Email Service
 description: Production-ready email service for sending emails in Servercn using nodemailer with support for multiple providers (Nodemailer, Resend, Mailtrap, etc.).
-command: npx servercn-cli add email-service
+command: npx servercn-cli@latest add email-service
 contributor:
  -  name: Akkal Dhami
     url: https://www.akkal.com.np
@@ -18,7 +18,7 @@ The **Email Service** component provides a production-ready solution for sending
 
 Install this component using the following command:
 
-<PackageManagerTabs command="npx servercn-cli add email-service" />
+<PackageManagerTabs command="npx servercn-cli@latest add email-service" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/env-config.mdx
+++ b/apps/web/src/content/docs/express/components/env-config.mdx
@@ -1,7 +1,7 @@
 ---
 title: Env Configuration
 description: Setup type-safe environment variables with Zod and Dotenv.
-command: npx servercn-cli add env-config
+command: npx servercn-cli@latest add env-config
 ---
 
 # Env Configuration
@@ -13,7 +13,7 @@ Environment variables are a critical part of any production application. They al
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add env-config" />
+<PackageManagerTabs command="npx servercn-cli@latest add env-config" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/error-handler.mdx
+++ b/apps/web/src/content/docs/express/components/error-handler.mdx
@@ -1,7 +1,7 @@
 ---
 title: API Error Handler
 description: A lightweight, production-ready error handling utility for Express applications.
-command: npx servercn-cli add error-handler
+command: npx servercn-cli@latest add error-handler
 ---
 
 # API Error Handling
@@ -12,7 +12,7 @@ A lightweight, production-ready error handling utility for **Express** applicati
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add error-handler" />
+<PackageManagerTabs command="npx servercn-cli@latest add error-handler" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/file-upload-cloudinary.mdx
+++ b/apps/web/src/content/docs/express/components/file-upload-cloudinary.mdx
@@ -2,7 +2,7 @@
 title: File Upload (Cloudinary)
 description: The File Upload component provides a standardized way to handle file uploads in Servercn using Cloudinary as the storage provider.
 
-command: npx servercn-cli add file-upload
+command: npx servercn-cli@latest add file-upload
 ---
 
 # File Upload (Cloudinary)
@@ -20,7 +20,7 @@ The **File Upload** component provides a standardized way to handle file uploads
 
 This component requires additional Servercn components.
 
-<PackageManagerTabs command="npx servercn-cli add file-upload" />
+<PackageManagerTabs command="npx servercn-cli@latest add file-upload" />
 
 You will be prompted to select a file upload provider:
 

--- a/apps/web/src/content/docs/express/components/file-upload-imagekit.mdx
+++ b/apps/web/src/content/docs/express/components/file-upload-imagekit.mdx
@@ -2,7 +2,7 @@
 title: File Upload (ImageKit)
 description: The File Upload component provides a standardized way to handle file uploads in Servercn using ImageKit as the storage provider.
 
-command: npx servercn-cli add file-upload
+command: npx servercn-cli@latest add file-upload
 ---
 
 # File Upload (ImageKit)
@@ -18,7 +18,7 @@ The **File Upload** component provides a standardized way to handle file uploads
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add file-upload" />
+<PackageManagerTabs command="npx servercn-cli@latest add file-upload" />
 
 You will be prompted to select a file upload provider:
 

--- a/apps/web/src/content/docs/express/components/generate-otp-token.mdx
+++ b/apps/web/src/content/docs/express/components/generate-otp-token.mdx
@@ -1,7 +1,7 @@
 ---
 title: Generate OTP/Token Helper Functions
 description: Cryptographically secure utility functions for generating OTPs, random tokens, and unique identifiers for authentication workflows.
-command: npx servercn-cli add generate-otp-token
+command: npx servercn-cli@latest add generate-otp-token
 ---
 
 # Generate OTP/Token Helper Functions
@@ -13,7 +13,7 @@ Cryptographically secure utility functions for generating OTPs, random tokens, a
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add generate-otp-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add generate-otp-token" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/github-google-oauth.mdx
+++ b/apps/web/src/content/docs/express/components/github-google-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: GitHub & Google OAuth
 description: Secure GitHub & Google OAuth authentication integration using passport, passport-google-oauth20 and passport-github2 for Express applications.
-command: npx servercn-cli add oauth
+command: npx servercn-cli@latest add oauth
 ---
 
 # GitHub & Google OAuth (Passport)
@@ -14,7 +14,7 @@ The **GitHub & Google OAuth** component provides a secure and standardized way t
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add oauth" />
+<PackageManagerTabs command="npx servercn-cli@latest add oauth" />
 
 You will be prompted to select a file upload provider:
 

--- a/apps/web/src/content/docs/express/components/github-oauth.mdx
+++ b/apps/web/src/content/docs/express/components/github-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: GitHub OAuth
 description: Secure GitHub OAuth authentication integration using passport, passport-github2 for Express applications.
-command: npx servercn-cli add oauth
+command: npx servercn-cli@latest add oauth
 ---
 
 # GitHub OAuth (Passport)
@@ -14,7 +14,7 @@ The **GitHub OAuth** component provides a secure and standardized way to integra
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add oauth" />
+<PackageManagerTabs command="npx servercn-cli@latest add oauth" />
 
 You will be prompted to select a file upload provider:
 

--- a/apps/web/src/content/docs/express/components/global-error-handler.mdx
+++ b/apps/web/src/content/docs/express/components/global-error-handler.mdx
@@ -1,7 +1,7 @@
 ---
 title: Global Error Handler
 description: Centralized error handling for Express applications using TypeScript.
-command: npx servercn-cli add global-error-handler
+command: npx servercn-cli@latest add global-error-handler
 ---
 
 # Global Error Handling
@@ -12,7 +12,7 @@ A <Code children="global error handler" /> is a core part of any production-read
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add global-error-handler" />
+<PackageManagerTabs command="npx servercn-cli@latest add global-error-handler" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/google-oauth.mdx
+++ b/apps/web/src/content/docs/express/components/google-oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: Google OAuth
 description: Secure Google OAuth authentication integration using passport, passport-google-oauth20 for Express applications.
-command: npx servercn-cli add oauth
+command: npx servercn-cli@latest add oauth
 ---
 
 # Google OAuth (Passport)
@@ -14,7 +14,7 @@ The **Google OAuth** component provides a secure and standardized way to integra
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add oauth" />
+<PackageManagerTabs command="npx servercn-cli@latest add oauth" />
 
 You will be prompted to select a file upload provider:
 

--- a/apps/web/src/content/docs/express/components/health-check.mdx
+++ b/apps/web/src/content/docs/express/components/health-check.mdx
@@ -1,7 +1,7 @@
 ---
 title: Health Check
 description: Production-ready health check endpoints for monitoring API status, database connectivity, and system health in Express applications.
-command: npx servercn-cli add health-check
+command: npx servercn-cli@latest add health-check
 ---
 
 # Health Check
@@ -12,7 +12,7 @@ The **Health Check** component provides production-ready endpoints for monitorin
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add health-check" />
+<PackageManagerTabs command="npx servercn-cli@latest add health-check" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/http-status-codes.mdx
+++ b/apps/web/src/content/docs/express/components/http-status-codes.mdx
@@ -1,7 +1,7 @@
 ---
 title: HTTP Status Codes
 description: Centralized, type-safe HTTP status codes for consistent API responses.
-command: npx servercn-cli add http-status-codes
+command: npx servercn-cli@latest add http-status-codes
 ---
 
 # HTTP Status Codes
@@ -14,7 +14,7 @@ The **HTTP Status Codes** component provides a **centralized and type-safe** way
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add http-status-codes" />
+<PackageManagerTabs command="npx servercn-cli@latest add http-status-codes" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/jwt-utils.mdx
+++ b/apps/web/src/content/docs/express/components/jwt-utils.mdx
@@ -1,7 +1,7 @@
 ---
 title: JWT Utils Function
 description: JWT Utils Function for JSON Web Token authentication with access & refresh token support for Express
-command: npx servercn-cli add jwt-utils
+command: npx servercn-cli@latest add jwt-utils
 ---
 
 # JWT Utils Function
@@ -14,7 +14,7 @@ JWT Utils Function provides a **production-ready authentication utility** based 
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add jwt-utils" />
+<PackageManagerTabs command="npx servercn-cli@latest add jwt-utils" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/logger.mdx
+++ b/apps/web/src/content/docs/express/components/logger.mdx
@@ -1,7 +1,7 @@
 ---
 title: Logger
 description: Structured and configurable logging for Node.js applications using Winston or Pino.
-command: npx servercn-cli add logger
+command: npx servercn-cli@latest add logger
 ---
 
 # Logger
@@ -20,7 +20,7 @@ The Servercn Logger component provides **two interchangeable logging strategies*
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add logger" />
+<PackageManagerTabs command="npx servercn-cli@latest add logger" />
 
 You will be prompted to select a file upload provider:
 

--- a/apps/web/src/content/docs/express/components/not-found-handler.mdx
+++ b/apps/web/src/content/docs/express/components/not-found-handler.mdx
@@ -1,7 +1,7 @@
 ---
 title: Not Found Handler
 description: The Not Found Handler component provides a centralized and consistent way to handle **unmatched routes**.
-command: npx servercn-cli add not-found-handler
+command: npx servercn-cli@latest add not-found-handler
 ---
 
 # Not Found Handler
@@ -12,7 +12,7 @@ The Not Found Handler component provides a centralized and consistent way to han
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add not-found-handler" />
+<PackageManagerTabs command="npx servercn-cli@latest add not-found-handler" />
 
 This component requires the **API Error Handler** component to function correctly.
 

--- a/apps/web/src/content/docs/express/components/oauth.mdx
+++ b/apps/web/src/content/docs/express/components/oauth.mdx
@@ -1,7 +1,7 @@
 ---
 title: OAuth | Component
 description: Add authentication to your backend using prebuilt OAuth providers like Google, Facebook, and GitHub.
-command: npx servercn-cli add oauth
+command: npx servercn-cli@latest add oauth
 ---
 
 # OAuth Component
@@ -20,10 +20,10 @@ All under a single, consistent architecture.
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add oauth" />
+<PackageManagerTabs command="npx servercn-cli@latest add oauth" />
 
 ```bash
-npx servercn-cli add oauth
+npx servercn-cli@latest add oauth
 
 ? Select OAuth provider:  » - Use arrow-keys. Return to submit.
 > Google

--- a/apps/web/src/content/docs/express/components/password-hashing.mdx
+++ b/apps/web/src/content/docs/express/components/password-hashing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Password Hashing
 description: Secure password hashing utilities using argon2, bcryptjs, scrypt, and pbkdf2.
-command: npx servercn-cli add password-hashing
+command: npx servercn-cli@latest add password-hashing
 
 ---
 
@@ -24,7 +24,7 @@ Supported algorithms:
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add password-hashing" />
+<PackageManagerTabs command="npx servercn-cli@latest add password-hashing" />
 
 You will be prompted to select a password hashing strategy:
 

--- a/apps/web/src/content/docs/express/components/rbac.mdx
+++ b/apps/web/src/content/docs/express/components/rbac.mdx
@@ -1,7 +1,7 @@
 ---
 title: Role Based Access Control (RBAC)
 description: Secure your Express application by restricting access to resources based on assigned user roles.
-command: npx servercn-cli add rbac
+command: npx servercn-cli@latest add rbac
 ---
 
 # Role Based Access Control (RBAC)
@@ -12,7 +12,7 @@ The **RBAC** component provides a clean and reusable middleware to restrict API 
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add rbac" />
+<PackageManagerTabs command="npx servercn-cli@latest add rbac" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/request-validator.mdx
+++ b/apps/web/src/content/docs/express/components/request-validator.mdx
@@ -1,7 +1,7 @@
 ---
 title: Request Validator (Zod)
 description: The Request Validator component provides a standardized way to validate request data in Servercn using **Zod** schemas.
-command: npx servercn-cli add request-validator
+command: npx servercn-cli@latest add request-validator
 ---
 
 # Request Validator (Zod)
@@ -12,7 +12,7 @@ The **Request Validator** component provides a standardized way to validate requ
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add request-validator" />
+<PackageManagerTabs command="npx servercn-cli@latest add request-validator" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/response-formatter.mdx
+++ b/apps/web/src/content/docs/express/components/response-formatter.mdx
@@ -1,7 +1,7 @@
 ---
 title: API Response Formatter
 description: A standardized, type-safe API response wrapper for Express applications.
-command: npx servercn-cli add response-formatter
+command: npx servercn-cli@latest add response-formatter
 ---
 
 # API Response Formatter
@@ -13,7 +13,7 @@ The <Code>API Response Formatter</Code> component provides a **consistent, predi
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add response-formatter" />
+<PackageManagerTabs command="npx servercn-cli@latest add response-formatter" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/security-header.mdx
+++ b/apps/web/src/content/docs/express/components/security-header.mdx
@@ -1,7 +1,7 @@
 ---
 title: Security Headers
 description: A standardized, production-ready security header configuration for Express applications using Helmet and CORS.
-command: npx servercn-cli add security-header
+command: npx servercn-cli@latest add security-header
 ---
 
 # Security Headers
@@ -14,7 +14,7 @@ command: npx servercn-cli add security-header
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add security-header" />
+<PackageManagerTabs command="npx servercn-cli@latest add security-header" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/shutdown-handler.mdx
+++ b/apps/web/src/content/docs/express/components/shutdown-handler.mdx
@@ -1,7 +1,7 @@
 ---
 title: Graceful Shutdown Handler
 description: A standardized way to handle graceful shutdowns in Express applications, ensuring all requests are finished and resources are released.
-command: npx servercn-cli add shutdown-handler
+command: npx servercn-cli@latest add shutdown-handler
 ---
 
 # Graceful Shutdown Handler
@@ -14,7 +14,7 @@ The **Graceful Shutdown Handler** ensures that your Express application terminat
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add shutdown-handler" />
+<PackageManagerTabs command="npx servercn-cli@latest add shutdown-handler" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/swagger-docs.mdx
+++ b/apps/web/src/content/docs/express/components/swagger-docs.mdx
@@ -1,7 +1,7 @@
 ---
 title: Swagger API Documentation
 description: Set up automated OpenAPI documentation for your Express API using Swagger JSDoc and Swagger UI.
-command: npx servercn-cli add swagger-docs
+command: npx servercn-cli@latest add swagger-docs
 ---
 
 # Swagger API Documentation
@@ -10,16 +10,30 @@ The **Swagger API Documentation** component provides an automated way to generat
 
 ---
 
-## Installation
+## Installation Guide
 
-Install the component using the servercn CLI:
+<Tabs defaultValue="cli">
+<TabsList>
+<TabsTrigger value="cli">
+Command
+</TabsTrigger>
+<TabsTrigger value="manual">
+Manual
+</TabsTrigger>
+</TabsList>
 
-<PackageManagerTabs command="npx servercn-cli add swagger-docs" />
+<TabsContent value="cli">
+<PackageManagerTabs command="npx servercn-cli@latest add swagger-docs" />
+</TabsContent>
 
----
-
-## Implementation Guide
+<TabsContent value="manual">
 <Steps>
+<Step>Install Dependencies:</Step>
+<PackageManagerTabs command="npm install swagger-autogen swagger-ui-express" />
+<PackageManagerTabs command="npm install -D @types/swagger-ui-express" />
+
+
+
 <Step>Configuration</Step>
 
 The configuration file defines the metadata for your API and where Swagger should look for documentation comments.
@@ -100,7 +114,8 @@ app.listen(8000, () => {
 Update the <Code children="swagger.json" /> file with the new API documentation.
 
 </Steps>
-
+</TabsContent>
+</Tabs>
 ---
 
 ## Accessing the Docs

--- a/apps/web/src/content/docs/express/components/validate-objectid.mdx
+++ b/apps/web/src/content/docs/express/components/validate-objectid.mdx
@@ -1,7 +1,7 @@
 ---
 title: Validate ObjectId Middleware
 description: Middleware to validate MongoDB ObjectId parameters in Express routes.
-command: npx servercn-cli add validate-objectid
+command: npx servercn-cli@latest add validate-objectid
 ---
 
 # Validate ObjectId Middleware
@@ -14,7 +14,7 @@ The **Validate ObjectId Middleware** ensures that route parameters intended to b
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add validate-objectid" />
+<PackageManagerTabs command="npx servercn-cli@latest add validate-objectid" />
 
 ---
 

--- a/apps/web/src/content/docs/express/components/verify-auth-middleware.mdx
+++ b/apps/web/src/content/docs/express/components/verify-auth-middleware.mdx
@@ -1,7 +1,7 @@
 ---
 title: Verify Authentication Middleware
 description: Express middleware to verify user authentication using access and refresh tokens.
-command: npx servercn-cli add verify-auth-middleware
+command: npx servercn-cli@latest add verify-auth-middleware
 ---
 
 # Verify Authentication Middleware
@@ -29,7 +29,7 @@ This ensures **seamless token rotation** without forcing the user to re-login.
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add verify-auth-middleware" />
+<PackageManagerTabs command="npx servercn-cli@latest add verify-auth-middleware" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/cloudinary-storage.mdx
+++ b/apps/web/src/content/docs/express/providers/cloudinary-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: Cloudinary Storage | Provider
 description: Cloudinary media upload and storage provider with Multer for Express applications.
-command: npx servercn-cli add pr cloudinary-storage
+command: npx servercn-cli@latest add pr cloudinary-storage
 ---
 
 # Cloudinary Storage Provider
@@ -12,7 +12,7 @@ This provider adds [Cloudinary](https://cloudinary.com/) SDK configuration, Zod-
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr cloudinary-storage" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr cloudinary-storage" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/imagekit-storage.mdx
+++ b/apps/web/src/content/docs/express/providers/imagekit-storage.mdx
@@ -1,7 +1,7 @@
 ---
 title: ImageKit Storage | Provider
 description: ImageKit file upload and CDN storage provider with Multer for Express applications.
-command: npx servercn-cli add pr imagekit-storage
+command: npx servercn-cli@latest add pr imagekit-storage
 ---
 
 # ImageKit Storage Provider
@@ -12,7 +12,7 @@ This provider adds the [ImageKit Node SDK](https://github.com/imagekit-developer
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr imagekit-storage" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr imagekit-storage" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/mongodb-mongoose.mdx
+++ b/apps/web/src/content/docs/express/providers/mongodb-mongoose.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mongodb(Mongoose) | Provider
 description: MongoDB provider with Mongoose ORM for Express applications.
-command: npx servercn-cli add pr mongodb-mongoose
+command: npx servercn-cli@latest add pr mongodb-mongoose
 ---
 
 # Mongodb(Mongoose) Provider
@@ -12,7 +12,7 @@ This provider sets up MongoDB connectivity with Mongoose for Express projects, i
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr mongodb-mongoose" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr mongodb-mongoose" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/mongodb-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/mongodb-prisma.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mongodb(Prisma) | Provider
 description: MongoDB provider with Prisma ORM for Express applications.
-command: npx servercn-cli add pr mongodb-prisma
+command: npx servercn-cli@latest add pr mongodb-prisma
 ---
 
 # Mongodb(Prisma) Provider
@@ -12,7 +12,7 @@ This provider sets up MongoDB connectivity with Prisma for Express projects, inc
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr mongodb-prisma" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr mongodb-prisma" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/mysql-drizzle.mdx
+++ b/apps/web/src/content/docs/express/providers/mysql-drizzle.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mysql(Drizzle) | Provider
 description: Mysql provider with Drizzle ORM for Express applications.
-command: npx servercn-cli add pr mysql-drizzle
+command: npx servercn-cli@latest add pr mysql-drizzle
 ---
 
 # Mysql(Drizzle) Provider
@@ -12,7 +12,7 @@ This provider sets up MySQL connectivity with Drizzle ORM for Express projects, 
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr mysql-drizzle" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr mysql-drizzle" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/mysql-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/mysql-prisma.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mysql(Prisma) | Provider
 description: Mysql provider with Prisma ORM for Express applications.
-command: npx servercn-cli add pr mysql-prisma
+command: npx servercn-cli@latest add pr mysql-prisma
 ---
 
 # Mysql(Prisma) Provider
@@ -12,7 +12,7 @@ This provider sets up MySQL connectivity with Prisma for Express projects, inclu
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr mysql-prisma" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr mysql-prisma" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/nodemailer-smtp.mdx
+++ b/apps/web/src/content/docs/express/providers/nodemailer-smtp.mdx
@@ -1,7 +1,7 @@
 ---
 title: Nodemailer SMTP | Provider
 description: Transactional email provider using Nodemailer over SMTP for Express applications.
-command: npx servercn-cli add pr nodemailer-smtp
+command: npx servercn-cli@latest add pr nodemailer-smtp
 ---
 
 # Nodemailer SMTP Provider
@@ -12,7 +12,7 @@ This provider configures [Nodemailer](https://nodemailer.com/) with SMTP setting
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr nodemailer-smtp" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr nodemailer-smtp" />
 ---
 
 ## Basic Implementation

--- a/apps/web/src/content/docs/express/providers/pg-drizzle-neon.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-drizzle-neon.mdx
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL + Neon (Drizzle) | Provider
 description: PostgreSQL + Neon provider with Drizzle ORM for Express applications.
-command: npx servercn-cli add pr pg-drizzle-neon
+command: npx servercn-cli@latest add pr pg-drizzle-neon
 ---
 
 # PostgreSQL(Drizzle) Provider
@@ -12,7 +12,7 @@ This provider sets up PostgreSQL + Neon connectivity with Drizzle ORM for Expres
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr pg-drizzle-neon" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr pg-drizzle-neon" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/pg-drizzle.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-drizzle.mdx
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL(Drizzle) | Provider
 description: PostgreSQL provider with Drizzle ORM for Express applications.
-command: npx servercn-cli add pr pg-drizzle
+command: npx servercn-cli@latest add pr pg-drizzle
 ---
 
 # PostgreSQL(Drizzle) Provider
@@ -12,7 +12,7 @@ This provider sets up PostgreSQL connectivity with Drizzle ORM for Express proje
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr pg-drizzle" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr pg-drizzle" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/pg-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-prisma.mdx
@@ -1,7 +1,7 @@
 ---
 title: PostgreSQL(Prisma) | Provider
 description: PostgreSQL provider with Prisma ORM for Express applications.
-command: npx servercn-cli add pr pg-prisma
+command: npx servercn-cli@latest add pr pg-prisma
 ---
 
 # PostgreSQL(Prisma) Provider
@@ -12,7 +12,7 @@ This provider sets up PostgreSQL connectivity with Prisma for Express projects, 
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr pg-prisma" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr pg-prisma" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/redis.mdx
+++ b/apps/web/src/content/docs/express/providers/redis.mdx
@@ -1,7 +1,7 @@
 ---
 title: Redis | Provider
 description: Redis cache and key-value provider with the official Node client for Express applications.
-command: npx servercn-cli add pr redis
+command: npx servercn-cli@latest add pr redis
 ---
 
 # Redis Provider
@@ -12,7 +12,7 @@ This provider wires the official [redis](https://github.com/redis/node-redis) pa
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr redis" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr redis" />
 
 ---
 

--- a/apps/web/src/content/docs/express/providers/resend-mail.mdx
+++ b/apps/web/src/content/docs/express/providers/resend-mail.mdx
@@ -1,7 +1,7 @@
 ---
 title: Resend Mail | Provider
 description: Email provider using the Resend API for Express applications.
-command: npx servercn-cli add pr resend-mail
+command: npx servercn-cli@latest add pr resend-mail
 ---
 
 # Resend Mail Provider
@@ -12,7 +12,7 @@ This provider adds the official [Resend](https://resend.com/) SDK, validates <Co
 
 ## Installation Guide
 
-<PackageManagerTabs command="npx servercn-cli add pr resend-mail" />
+<PackageManagerTabs command="npx servercn-cli@latest add pr resend-mail" />
 
 ---
 

--- a/apps/web/src/content/docs/express/schemas/auth-mongodb.mdx
+++ b/apps/web/src/content/docs/express/schemas/auth-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Auth | MongoDB (Mongoose) | Schema
 description: Complete authentication system schemas for MongoDB using Mongoose, including User, OTP, Session, and Refresh Token models.
-command: npx servercn-cli add sc auth
+command: npx servercn-cli@latest add sc auth
 
 ---
 
@@ -15,7 +15,7 @@ The Auth Domain provides a set of production-ready models that handle user ident
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth" />
 
 During initialize the servercn in your project, select <Code children="MongoDB" /> when prompted for the database.
 
@@ -149,7 +149,7 @@ export default User;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/user" />
 
 ## 2. OTP Schema
 
@@ -253,7 +253,7 @@ export default Otp;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/otp" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/otp" />
 
 ## 3. Session Schema
 
@@ -331,7 +331,7 @@ export default Session;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/session" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/session" />
 
 ## 4. Refresh Token Schema
 
@@ -407,7 +407,7 @@ export default RefreshToken;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/refresh-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/refresh-token" />
 
 ## 5. Auth Constants
 

--- a/apps/web/src/content/docs/express/schemas/auth-mysql.mdx
+++ b/apps/web/src/content/docs/express/schemas/auth-mysql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Auth | MySQL (Drizzle) | Schema
 description: Complete authentication system schemas for MySQL using Drizzle ORM, including User, OTP, Session, and Refresh Token models.
-command: npx servercn-cli add schema auth
+command: npx servercn-cli@latest add schema auth
 ---
 
 # Auth Domain (MySQL with Drizzle)
@@ -12,7 +12,7 @@ This page documents the authentication schemas for projects using **MySQL** with
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth" />
 
 During installation, select **MySQL (Drizzle)** when prompted for the database.
 This will install all authentication-related schemas into the <Code children="src/drizzle/schemas" /> folder.
@@ -104,7 +104,7 @@ export type NewUser = typeof users.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/user" />
 
 ## 2. OTP Schema
 
@@ -165,7 +165,7 @@ export type NewOtp = typeof otps.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/otp" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/otp" />
 
 ## 3. Session Schema
 
@@ -223,7 +223,7 @@ export type NewSession = typeof sessions.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/session" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/session" />
 
 ## 4. Refresh Token Schema
 
@@ -286,7 +286,7 @@ export type NewRefreshToken = typeof refreshTokens.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/refresh-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/refresh-token" />
 
 ## 5. Export all schemas
 

--- a/apps/web/src/content/docs/express/schemas/auth-postgresql.mdx
+++ b/apps/web/src/content/docs/express/schemas/auth-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Auth | PostgreSQL (Drizzle) | Schema
 description: Complete authentication system schemas for PostgreSQL using Drizzle ORM, including User, OTP, Session, and Refresh Token models.
-command: npx servercn-cli add schema auth
+command: npx servercn-cli@latest add schema auth
 
 ---
 
@@ -13,7 +13,7 @@ This page documents the authentication schemas for projects using **PostgreSQL**
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth" />
 
 During installation, select **PostgreSQL (Drizzle)** when prompted for the database.
 This will install all authentication-related schemas into the <Code children="src/drizzle/schemas" /> folder.
@@ -107,7 +107,7 @@ export type NewUser = typeof users.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/user" />
 
 ## 2. OTP Schema
 
@@ -172,7 +172,7 @@ export type NewOtp = typeof otps.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/otp" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/otp" />
 
 ## 3. Session Schema
 
@@ -232,7 +232,7 @@ export type NewSession = typeof sessions.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/session" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/session" />
 
 ## 4. Refresh Token Schema
 
@@ -296,7 +296,7 @@ export type NewRefreshToken = typeof refreshTokens.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/refresh-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/refresh-token" />
 
 ## 5. Export all schemas
 

--- a/apps/web/src/content/docs/express/schemas/auth.mdx
+++ b/apps/web/src/content/docs/express/schemas/auth.mdx
@@ -1,7 +1,7 @@
 ---
 title: Auth Domain Schemas
 description: Complete authentication system schemas including User, OTP, and Session models for building secure authentication workflows.
-command: npx servercn-cli add sc auth
+command: npx servercn-cli@latest add sc auth
 ---
 
 # Auth Domain Schemas
@@ -40,7 +40,7 @@ Together, these schemas provide everything you need to build:
 
 To install all auth-related schemas at once, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth" />
 
 This will install:
 
@@ -58,19 +58,19 @@ You can also install schemas individually:
 
 **User Schema:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/user" />
 
 **OTP Schema:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/otp" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/otp" />
 
 **Session Schema:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/session" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/session" />
 
 **Refresh Token Schema:**
 
-<PackageManagerTabs command="npx servercn-cli add schema auth/refresh-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth/refresh-token" />
 
 ## Schemas Breakdown
 

--- a/apps/web/src/content/docs/express/schemas/banking-app-mongodb.mdx
+++ b/apps/web/src/content/docs/express/schemas/banking-app-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title:  Banking | MongoDB (Mongoose) | Schema
 description: A detailed look at the MongoDB schema for a modern banking application.
-command: npx servercn-cli add sc banking-app
+command: npx servercn-cli@latest add sc banking-app
 
 ---
 
@@ -15,7 +15,7 @@ The core of our application revolves around four main collections: <Code>User</C
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema banking-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app" />
 
 ## 1. User Schema
 
@@ -140,7 +140,7 @@ export default User;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/user" />
 
 ## 2. Account Schema
 
@@ -212,7 +212,7 @@ export default Account;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/account" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/account" />
 
 ## 3. Transaction Schema
 
@@ -280,7 +280,7 @@ export default Transaction;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/transaction" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/transaction" />
 
 ## 5. Ledger Schema
 
@@ -357,7 +357,7 @@ export const Ledger = model<ILedger>("Ledger", LedgerSchema);
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/ledger" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/ledger" />
 
 **Notes:**
 

--- a/apps/web/src/content/docs/express/schemas/banking-app-mysql.mdx
+++ b/apps/web/src/content/docs/express/schemas/banking-app-mysql.mdx
@@ -1,7 +1,7 @@
 ---
 title:  Banking | MySQL (Drizzle) | Schema
 description: A detailed look at the MySQL schema for a modern banking application using Drizzle ORM.
-command: npx servercn-cli add schema banking-app
+command: npx servercn-cli@latest add schema banking-app
 
 ---
 
@@ -15,7 +15,7 @@ The core of our application revolves around four main tables: <Code>User</Code>,
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema banking-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app" />
 
 <Note text="If you install schema individually, the relationships between them won't be automatic—you'll need to implement them manually." />
 
@@ -86,7 +86,7 @@ export type NewUser = typeof users.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/user" />
 
 ## 2. Account Schema
 
@@ -145,7 +145,7 @@ export type NewAccount = typeof accounts.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/account" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/account" />
 
 ## 3. Transaction Schema
 
@@ -208,7 +208,7 @@ export type NewTransaction = typeof transactions.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/transaction" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/transaction" />
 
 ## 4. Ledger Schema
 
@@ -261,7 +261,7 @@ export type NewLedger = typeof ledgers.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/ledger" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/ledger" />
 
 ## 5. Relations
 

--- a/apps/web/src/content/docs/express/schemas/banking-app-postgresql.mdx
+++ b/apps/web/src/content/docs/express/schemas/banking-app-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title:  Banking | PostgreSQL (Drizzle) | Schema
 description: A detailed look at the PostgreSQL schema for a modern banking application using Drizzle ORM.
-command: npx servercn-cli add schema banking-app
+command: npx servercn-cli@latest add schema banking-app
 
 ---
 
@@ -15,7 +15,7 @@ The core of our application revolves around four main tables: <Code>User</Code>,
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema banking-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app" />
 
 <Note text="If you install schema individually, the relationships between them won't be automatic—you'll need to implement them manually." />
 
@@ -99,7 +99,7 @@ export type NewUser = typeof users.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/user" />
 
 ## 2. Account Schema
 
@@ -152,7 +152,7 @@ export type NewAccount = typeof accounts.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/account" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/account" />
 
 ## 3. Transaction Schema
 
@@ -215,7 +215,7 @@ export type NewTransaction = typeof transactions.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/transaction" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/transaction" />
 
 ## 4. Ledger Schema
 
@@ -269,7 +269,7 @@ export type NewLedger = typeof ledgers.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/ledger" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/ledger" />
 
 ## 5. Relations
 

--- a/apps/web/src/content/docs/express/schemas/banking-app.mdx
+++ b/apps/web/src/content/docs/express/schemas/banking-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: Banking App Schema
 description: Production-ready Banking schemas with support for MongoDB, PostgreSQL, and MySQL databases.
-command: npx servercn-cli add sc banking-app
+command: npx servercn-cli@latest add sc banking-app
 ---
 
 # Banking App Schema
@@ -16,7 +16,7 @@ The Banking App Schema is a beginner-friendly schema for a banking application. 
 
 ## Installation all schemas
 
-<PackageManagerTabs command="npx servercn-cli add schema banking-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app" />
 
 ## Installation individual schema
 
@@ -24,19 +24,19 @@ The Banking App Schema is a beginner-friendly schema for a banking application. 
 
 ### 1. User
 
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/user" />
 
 ### 2. Account
 
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/account" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/account" />
 
 ### 3. Transaction
 
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/transaction" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/transaction" />
 
 ### 4. Ledger
 
-<PackageManagerTabs command="npx servercn-cli add schema banking-app/ledger" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema banking-app/ledger" />
 
 ## Learn more
 

--- a/apps/web/src/content/docs/express/schemas/blog-app-mongodb.mdx
+++ b/apps/web/src/content/docs/express/schemas/blog-app-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title:  Blog App | MongoDB (Mongoose) | Schema
 description: A detailed look at the MongoDB schema for a modern blog application.
-command: npx servercn-cli add sc blog-app
+command: npx servercn-cli@latest add sc blog-app
 
 ---
 
@@ -15,7 +15,7 @@ The core of our application revolves around four main collections: <Code>User</C
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app" />
 
 ## 1. User Schema
 
@@ -140,7 +140,7 @@ export default User;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/user" />
 
 ## 2. Post Schema
 
@@ -278,7 +278,7 @@ export default Post;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/post" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/post" />
 
 ## 3. Category Schema
 
@@ -328,7 +328,7 @@ export default Category;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/category" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/category" />
 
 ## 4. Comment Schema
 
@@ -403,7 +403,7 @@ export default Comment;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/comment" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/comment" />
 
 ## Key Features
 

--- a/apps/web/src/content/docs/express/schemas/blog-app-mysql.mdx
+++ b/apps/web/src/content/docs/express/schemas/blog-app-mysql.mdx
@@ -1,7 +1,7 @@
 ---
 title:  Blog App | MySQL (Drizzle) | Schema
 description: A detailed look at the MySQL schema for a modern blog application using Drizzle ORM.
-command: npx servercn-cli add schema blog-app
+command: npx servercn-cli@latest add schema blog-app
 
 ---
 
@@ -15,7 +15,7 @@ The core of our application revolves around six main tables: <Code>User</Code>, 
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app" />
 
 <Note text="If you install schema individually, the relationships between them won't be automatic—you'll need to implement them manually." />
 
@@ -84,7 +84,7 @@ export type NewUser = typeof users.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/user" />
 
 ## 2. Post Schema
 
@@ -148,7 +148,7 @@ export type Post = typeof posts.$inferSelect;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/post" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/post" />
 
 ## 3. Category Schema
 
@@ -180,7 +180,7 @@ export type Category = typeof categories.$inferSelect;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/category" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/category" />
 
 ## 4. Comment Schema
 
@@ -209,7 +209,7 @@ export const comments = mysqlTable("comments", {
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/comment" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/comment" />
 
 ## 5. Post Like Schema
 
@@ -239,7 +239,7 @@ export const postLikes = mysqlTable(
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/post-like" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/post-like" />
 
 ## 6. Comment Like Schema
 
@@ -271,7 +271,7 @@ export const commentLikes = mysqlTable(
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/comment-like" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/comment-like" />
 
 ## 7. Export all schemas
 

--- a/apps/web/src/content/docs/express/schemas/blog-app-postgresql.mdx
+++ b/apps/web/src/content/docs/express/schemas/blog-app-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title:  Blog App | PostgreSQL (Drizzle) | Schema
 description: A detailed look at the PostgreSQL schema for a modern blog application using Drizzle ORM.
-command: npx servercn-cli add schema blog-app
+command: npx servercn-cli@latest add schema blog-app
 
 ---
 
@@ -15,7 +15,7 @@ The core of our application revolves around six main tables: <Code>User</Code>, 
 
 To add these schemas to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app" />
 
 <Note text="If you install schema individually, the relationships between them won't be automatic—you'll need to implement them manually." />
 
@@ -88,7 +88,7 @@ export type NewUser = typeof users.$inferInsert;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/user" />
 
 ## 2. Post Schema
 
@@ -155,7 +155,7 @@ export type Post = typeof posts.$inferSelect;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/post" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/post" />
 
 ## 3. Category Schema
 
@@ -187,7 +187,7 @@ export type Category = typeof categories.$inferSelect;
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/category" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/category" />
 
 ## 4. Comment Schema
 
@@ -216,7 +216,7 @@ export const comments = pgTable("comments", {
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/comment" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/comment" />
 
 ## 5. Post Like Schema
 
@@ -246,7 +246,7 @@ export const postLikes = pgTable(
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/post-like" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/post-like" />
 
 ## 6. Comment Like Schema
 
@@ -278,7 +278,7 @@ export const commentLikes = pgTable(
 ```
 
 #### Installation
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/comment-like" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/comment-like" />
 
 ## 7. Export all schemas
 

--- a/apps/web/src/content/docs/express/schemas/blog-app.mdx
+++ b/apps/web/src/content/docs/express/schemas/blog-app.mdx
@@ -1,7 +1,7 @@
 ---
 title: Blog App Schema
 description: Production-ready Blog schemas with support for MongoDB, PostgreSQL, and MySQL databases.
-command: npx servercn-cli add sc blog-app
+command: npx servercn-cli@latest add sc blog-app
 ---
 
 # Blog App Schema
@@ -16,7 +16,7 @@ The Blog App Schema is a comprehensive schema for a blogging platform. It includ
 
 ## Installation all schemas
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app" />
 
 ## Installation individual schema
 
@@ -24,27 +24,27 @@ The Blog App Schema is a comprehensive schema for a blogging platform. It includ
 
 ### 1. User
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/user" />
 
 ### 2. Post
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/post" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/post" />
 
 ### 3. Category
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/category" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/category" />
 
 ### 4. Comment
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/comment" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/comment" />
 
 ### 5. Post Like
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/post-like" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/post-like" />
 
 ### 6. Comment Like
 
-<PackageManagerTabs command="npx servercn-cli add schema blog-app/comment-like" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema blog-app/comment-like" />
 
 ## Learn more
 

--- a/apps/web/src/content/docs/express/schemas/todo-mongodb.mdx
+++ b/apps/web/src/content/docs/express/schemas/todo-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Todo | MongoDB (Mongoose) | Schema
 description: Production-ready Todo schema for MongoDB using Mongoose, featuring full type safety and user associations.
-command: npx servercn-cli add schema todo
+command: npx servercn-cli@latest add schema todo
 
 ---
 
@@ -17,7 +17,7 @@ The Todo schema provides a production-ready model for managing tasks, complete w
 
 To add this schema to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema todo" />
 
 During initialization, ensure you select <Code children="MongoDB" /> when prompted for the database.
 
@@ -98,7 +98,7 @@ export default Todo;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema todo/todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema todo/todo" />
 
 ## User Model
 

--- a/apps/web/src/content/docs/express/schemas/todo-mysql.mdx
+++ b/apps/web/src/content/docs/express/schemas/todo-mysql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Todo | MySQL (Drizzle) | Schema
 description: Production-ready Todo schema for MySQL using Drizzle ORM, featuring type safety and performance optimizations.
-command: npx servercn-cli add schema todo
+command: npx servercn-cli@latest add schema todo
 
 ---
 
@@ -15,7 +15,7 @@ The MySQL implementation focuses on compatibility and performance, using standar
 
 To add this schema to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema todo" />
 
 During initialization, ensure you select <Code children="MySQL" /> when prompted for the database.
 
@@ -156,7 +156,7 @@ export type NewTodo = typeof todos.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema todo/todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema todo/todo" />
 
 ## 3. schema.helper.ts
 

--- a/apps/web/src/content/docs/express/schemas/todo-postgresql.mdx
+++ b/apps/web/src/content/docs/express/schemas/todo-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Todo | PostgreSQL (Drizzle) | Schema
 description: Production-ready Todo schema for PostgreSQL using Drizzle ORM, featuring type safety and relational mappings.
-command: npx servercn-cli add schema todo
+command: npx servercn-cli@latest add schema todo
 
 ---
 
@@ -16,7 +16,7 @@ The PostgreSQL implementation leverages strong types and relational integrity to
 
 To add this schema to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema todo" />
 
 During initialization, ensure you select <Code children="PostgreSQL" /> when prompted for the database.
 
@@ -160,7 +160,7 @@ export type NewTodo = typeof todos.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add schema todo/todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema todo/todo" />
 
 ## 3. schema.helper.ts
 

--- a/apps/web/src/content/docs/express/schemas/todo.mdx
+++ b/apps/web/src/content/docs/express/schemas/todo.mdx
@@ -1,7 +1,7 @@
 ---
 title: Todo App Schema
 description: Production-ready Todo schemas with support for MongoDB, PostgreSQL, and MySQL databases.
-command: npx servercn-cli add schema todo
+command: npx servercn-cli@latest add schema todo
 ---
 
 # Todo App Schema
@@ -36,7 +36,7 @@ To see the complete database design, including the User schema from the Auth Dom
 
 To add the Todo schema to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add schema todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema todo" />
 
 This will install the appropriate schema file based on your project's database configuration.
 
@@ -71,7 +71,7 @@ This schema assumes you have the **Auth Domain** installed. The
 - Automatically delete todos when a user account is deleted (Cascading).
 
 To install the Auth Domain alongside Todos:
-<PackageManagerTabs command="npx servercn-cli add schema auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add schema auth" />
 
 ## Learn More
 

--- a/apps/web/src/content/docs/guides/installation.mdx
+++ b/apps/web/src/content/docs/guides/installation.mdx
@@ -46,7 +46,7 @@ Choose the foundation that best fits your project requirements and press Enter t
 
 ### 2. Add your first component
 
-<PackageManagerTabs command="npx servercn-cli add error-handler" />
+<PackageManagerTabs command="npx servercn-cli@latest add error-handler" />
 
 ## Servercn Foundations (Recommended)
 
@@ -171,13 +171,13 @@ Once initialized, you can add components to your project:
 
 ```bash
 # Add a component
-npx servercn-cli add <component-name>
+npx servercn-cli@latest add <component-name>
 
 # Examples
-npx servercn-cli add error-handler
+npx servercn-cli@latest add error-handler
 
 # Add multiple components
-npx servercn-cli add jwt-utils http-status-codes
+npx servercn-cli@latest add jwt-utils http-status-codes
 ```
 
 ---
@@ -200,7 +200,7 @@ After updating, new components will use the updated configuration.
 
 After installation:
 
-1. **Add your first component**: <Code children="npx servercn-cli add error-handler" />
+1. **Add your first component**: <Code children="npx servercn-cli@latest add error-handler" />
 2. **Set up your Express app**: Create <Code children='src/app.ts' />
 3. **Add more components**: Explore available components with <Code children="npx servercn-cli list" />
 4. **Read component docs**: Each component has detailed documentation

--- a/apps/web/src/content/docs/guides/js-guide.mdx
+++ b/apps/web/src/content/docs/guides/js-guide.mdx
@@ -144,10 +144,10 @@ Update your <Code>tsconfig.json</Code> file by replacing its content with the fo
 
 Now add the component you want.
 
-<PackageManagerTabs command="npx servercn-cli add error-handler" />
-<PackageManagerTabs command="npx servercn-cli add oauth" />
-<PackageManagerTabs command="npx servercn-cli add email-service" />
-<PackageManagerTabs command="npx servercn-cli add file-upload" />
+<PackageManagerTabs command="npx servercn-cli@latest add error-handler" />
+<PackageManagerTabs command="npx servercn-cli@latest add oauth" />
+<PackageManagerTabs command="npx servercn-cli@latest add email-service" />
+<PackageManagerTabs command="npx servercn-cli@latest add file-upload" />
 
 - [View Components](https://servercn.vercel.app/components)
 - [View Blueprints](https://servercn.vercel.app/blueprints)

--- a/apps/web/src/content/docs/nestjs/components/health-check.mdx
+++ b/apps/web/src/content/docs/nestjs/components/health-check.mdx
@@ -1,7 +1,7 @@
 ---
 title: Health Check
 description: Production-ready health check endpoints for monitoring API status, database connectivity, and system health in NestJS applications.
-command: npx servercn-cli add health-check
+command: npx servercn-cli@latest add health-check
 ---
 
 # Health Check
@@ -20,7 +20,7 @@ Manual
 </TabsTrigger>
 </TabsList>
 <TabsContent value="command">
-    <PackageManagerTabs command="npx servercn-cli add health-check"/>
+    <PackageManagerTabs command="npx servercn-cli@latest add health-check"/>
 </TabsContent>
 <TabsContent value="manual">
 <Steps>

--- a/apps/web/src/content/docs/nextjs/components/http-status-codes.mdx
+++ b/apps/web/src/content/docs/nextjs/components/http-status-codes.mdx
@@ -1,7 +1,7 @@
 ---
 title: HTTP Status Codes | Next.js
 description: Centralized, type-safe HTTP status codes for consistent Next.js API responses.
-command: npx servercn-cli add http-status-codes
+command: npx servercn-cli@latest add http-status-codes
 ---
 
 # HTTP Status Codes
@@ -14,7 +14,7 @@ Instead of hard-coded numbers like <Code children="200" /> or <Code children="40
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add http-status-codes" />
+<PackageManagerTabs command="npx servercn-cli@latest add http-status-codes" />
 
 ---
 

--- a/apps/web/src/content/docs/nextjs/components/jwt-utils.mdx
+++ b/apps/web/src/content/docs/nextjs/components/jwt-utils.mdx
@@ -1,7 +1,7 @@
 ---
 title: JWT Utils | Next.js
 description: JWT signing/verifying helpers (access + refresh) for Next.js templates.
-command: npx servercn-cli add jwt-utils
+command: npx servercn-cli@latest add jwt-utils
 ---
 
 # JWT Utils Function
@@ -20,7 +20,7 @@ The <Code>jwt-utils</Code> component is a small wrapper around <Code children="j
 
 Install the component using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add jwt-utils" />
+<PackageManagerTabs command="npx servercn-cli@latest add jwt-utils" />
 
 ## Environment variables
 

--- a/apps/web/src/content/docs/nextjs/foundations/nextjs-starter.mdx
+++ b/apps/web/src/content/docs/nextjs/foundations/nextjs-starter.mdx
@@ -60,7 +60,7 @@ public/
 
 You can keep this as a clean Next.js base or layer Servercn components on top:
 
-<PackageManagerTabs command="npx servercn-cli add component <component-name>" />
+<PackageManagerTabs command="npx servercn-cli@latest add component <component-name>" />
 
 ## Summary
 

--- a/apps/web/src/content/docs/nextjs/schemas/auth-mongodb.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/auth-mongodb.mdx
@@ -17,7 +17,7 @@ The Auth Domain provides a set of production-ready models that handle user ident
 
 Add these schemas using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add sc auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth" />
 
 ---
 
@@ -140,7 +140,7 @@ export default User;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/user" />
 
 ---
 
@@ -242,7 +242,7 @@ export default Otp;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/otp" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/otp" />
 
 ---
 
@@ -318,7 +318,7 @@ export default Session;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/session" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/session" />
 
 ---
 
@@ -391,7 +391,7 @@ export default RefreshToken;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/refresh-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/refresh-token" />
 
 ---
 

--- a/apps/web/src/content/docs/nextjs/schemas/auth-mysql.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/auth-mysql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Auth | MySQL (Drizzle) | Schema
 description: Complete authentication system schemas for MySQL using Drizzle ORM, including User, OTP, Session, and Refresh Token models.
-command: npx servercn-cli add schema auth
+command: npx servercn-cli@latest add schema auth
 ---
 
 # Auth Domain (MySQL with Drizzle)
@@ -14,7 +14,7 @@ This page documents the authentication schemas for projects using **MySQL** with
 
 Add these schemas using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add sc auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth" />
 
 
 <Note text="If you install schema one by one (such as auth/user and auth/session), the relationships between them won't be automatic—you'll need to implement them manually." />
@@ -96,7 +96,7 @@ export type NewUser = typeof users.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/user" />
 
 ---
 
@@ -155,7 +155,7 @@ export type NewOtp = typeof otps.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/otp" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/otp" />
 
 ---
 
@@ -212,7 +212,7 @@ export type NewSession = typeof sessions.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/session" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/session" />
 
 ---
 
@@ -274,7 +274,7 @@ export type NewRefreshToken = typeof refreshTokens.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/refresh-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/refresh-token" />
 
 ---
 

--- a/apps/web/src/content/docs/nextjs/schemas/auth-postgresql.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/auth-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Auth | PostgreSQL (Drizzle) | Schema
 description: Complete authentication system schemas for PostgreSQL using Drizzle ORM, including User, OTP, Session, and Refresh Token models.
-command: npx servercn-cli add sc auth
+command: npx servercn-cli@latest add sc auth
 
 ---
 
@@ -15,7 +15,7 @@ This page documents the authentication schemas for projects using **PostgreSQL**
 
 Add these schemas using the servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add sc auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth" />
 
 <Note text="If you install schema one by one (such as auth/user and auth/session), the relationships between them won't be automatic—you'll need to implement them manually." />
 
@@ -99,7 +99,7 @@ export type NewUser = typeof users.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/user" />
 
 ---
 
@@ -162,7 +162,7 @@ export type NewOtp = typeof otps.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/otp" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/otp" />
 
 ---
 
@@ -221,7 +221,7 @@ export type NewSession = typeof sessions.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/session" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/session" />
 
 ---
 
@@ -283,7 +283,7 @@ export type NewRefreshToken = typeof refreshTokens.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc auth/refresh-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/refresh-token" />
 
 ---
 

--- a/apps/web/src/content/docs/nextjs/schemas/auth.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/auth.mdx
@@ -1,7 +1,7 @@
 ---
 title: Auth Domain Schemas
 description: Complete authentication system schemas including User, OTP, Session, and Refresh Token models for Next.js (template reference).
-command: npx servercn-cli add sc auth
+command: npx servercn-cli@latest add sc auth
 ---
 
 # Auth Domain Schemas (Next.js)
@@ -28,21 +28,21 @@ Each schema exists in multiple variants for:
 
 ### Install everything
 
-<PackageManagerTabs command="npx servercn-cli add sc auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth" />
 
 ### Install individual parts
 
 **User:** 
-<PackageManagerTabs command="npx servercn-cli add sc auth/user" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/user" />
 
 **OTP:** 
-<PackageManagerTabs command="npx servercn-cli add sc auth/otp" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/otp" />
 
 **Session:** 
-<PackageManagerTabs command="npx servercn-cli add sc auth/session" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/session" />
 
 **Refresh Token:** 
-<PackageManagerTabs command="npx servercn-cli add sc auth/refresh-token" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth/refresh-token" />
 
 ## Schema summaries
 

--- a/apps/web/src/content/docs/nextjs/schemas/todo-mongodb.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/todo-mongodb.mdx
@@ -1,7 +1,7 @@
 ---
 title: Todo | MongoDB (Mongoose) | Schema
 description: Production-ready Todo schema for MongoDB using Mongoose, featuring full type safety and user associations.
-command: npx servercn-cli add sc todo
+command: npx servercn-cli@latest add sc todo
 
 ---
 
@@ -17,7 +17,7 @@ The Todo schema provides a production-ready model for managing tasks, complete w
 
 To add this schema to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add sc todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc todo" />
 
 ---
 
@@ -94,7 +94,7 @@ export default Todo;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc todo/todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc todo/todo" />
 
 ---
 

--- a/apps/web/src/content/docs/nextjs/schemas/todo-mysql.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/todo-mysql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Todo | MySQL (Drizzle) | Schema
 description: Production-ready Todo schema for MySQL using Drizzle ORM, featuring type safety and performance optimizations.
-command: npx servercn-cli add sc todo
+command: npx servercn-cli@latest add sc todo
 
 ---
 
@@ -17,7 +17,7 @@ The MySQL implementation focuses on compatibility and performance, using standar
 
 To add this schema to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add sc todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc todo" />
 
 ---
 
@@ -159,7 +159,7 @@ export type NewTodo = typeof todos.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc todo/todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc todo/todo" />
 
 ---
 

--- a/apps/web/src/content/docs/nextjs/schemas/todo-postgresql.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/todo-postgresql.mdx
@@ -1,7 +1,7 @@
 ---
 title: Todo | PostgreSQL (Drizzle) | Schema
 description: Production-ready Todo schema for PostgreSQL using Drizzle ORM, featuring type safety and relational mappings.
-command: npx servercn-cli add sc todo
+command: npx servercn-cli@latest add sc todo
 
 ---
 
@@ -17,7 +17,7 @@ The PostgreSQL implementation leverages strong types and relational integrity to
 
 To add this schema to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add sc todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc todo" />
 
 ---
 
@@ -161,7 +161,7 @@ export type NewTodo = typeof todos.$inferInsert;
 
 **Installation:**
 
-<PackageManagerTabs command="npx servercn-cli add sc todo/todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc todo/todo" />
 
 ---
 

--- a/apps/web/src/content/docs/nextjs/schemas/todo.mdx
+++ b/apps/web/src/content/docs/nextjs/schemas/todo.mdx
@@ -1,7 +1,7 @@
 ---
 title: Todo App Schema
 description: Production-ready Todo schemas with support for MongoDB, PostgreSQL, and MySQL databases.
-command: npx servercn-cli add sc todo
+command: npx servercn-cli@latest add sc todo
 ---
 
 # Todo App Schema (Next.js)
@@ -36,7 +36,7 @@ To see the complete database design, including the User schema from the Auth Dom
 
 To add the Todo schema to your project, run:
 
-<PackageManagerTabs command="npx servercn-cli add sc todo" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc todo" />
 
 This will install the appropriate schema file based on your project's database configuration.
 
@@ -71,7 +71,7 @@ This schema assumes you have the **Auth Domain** installed. The
 - Automatically delete todos when a user account is deleted (Cascading).
 
 To install the Auth Domain alongside Todos:
-<PackageManagerTabs command="npx servercn-cli add sc auth" />
+<PackageManagerTabs command="npx servercn-cli@latest add sc auth" />
 
 ## Learn More
 

--- a/apps/web/src/content/docs/tooling/commitlint.mdx
+++ b/apps/web/src/content/docs/tooling/commitlint.mdx
@@ -1,7 +1,7 @@
 ---
 title: Commitlint
 description: A production-ready Commitlint configuration for TypeScript and Express.js projects, with clear rules and enforced Git commit standards.
-command: npx servercn-cli add tooling commitlint
+command: npx servercn-cli@latest add tooling commitlint
 ---
 
 # Commitlint
@@ -22,7 +22,7 @@ This component is designed for **TypeScript + Express.js** backends but works fo
 
 Install Commitlint using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add tooling commitlint" />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling commitlint" />
 
 This command automatically:
 
@@ -145,7 +145,7 @@ BREAKING CHANGE: old refresh tokens are now invalidated on use
 
 Commitlint is most effective when enforced via Git hooks. Servercn is designed to work seamlessly with **Husky**.
 
-<PackageManagerTabs command="npx servercn-cli add tooling husky" />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling husky" />
 
 This ensures:
 
@@ -175,4 +175,4 @@ This makes it suitable for **production-grade backend systems** and **team-based
 
 ## Add More Tooling
 
-<PackageManagerTabs command="npx servercn-cli add tooling commitlint husky eslint prettier lint-staged typescript " />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling commitlint husky eslint prettier lint-staged typescript " />

--- a/apps/web/src/content/docs/tooling/eslint.mdx
+++ b/apps/web/src/content/docs/tooling/eslint.mdx
@@ -2,7 +2,7 @@
 
 title: ESLint
 description: A production-grade ESLint configuration for TypeScript and Express.js projects, optimized for backend reliability and team consistency.
-command: npx servercn-cli add tooling eslint
+command: npx servercn-cli@latest add tooling eslint
 ---
 
 # ESLint
@@ -24,7 +24,7 @@ This configuration is tailored specifically for **Node.js, TypeScript, and Expre
 
 Install the ESLint configuration using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add tooling eslint" />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling eslint" />
 
 This command automatically:
 
@@ -142,4 +142,4 @@ This makes it suitable for **serious backend systems** and **resume-grade projec
 
 ## Add More Tooling
 
-<PackageManagerTabs command="npx servercn-cli add tooling commitlint husky eslint prettier lint-staged typescript " />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling commitlint husky eslint prettier lint-staged typescript " />

--- a/apps/web/src/content/docs/tooling/husky.mdx
+++ b/apps/web/src/content/docs/tooling/husky.mdx
@@ -1,7 +1,7 @@
 ---
 title: Husky
 description: A robust Husky configuration for TypeScript and Express.js projects.
-command: npx servercn-cli add tooling husky
+command: npx servercn-cli@latest add tooling husky
 ---
 
 # Husky
@@ -14,7 +14,7 @@ Husky is a tool that allows you to easily manage Git hooks. Git hooks are script
 
 Install Husky using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add tooling husky" />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling husky" />
 
 ## Scripts
 
@@ -50,4 +50,4 @@ This hook executes automatically every time you attempt to create a commit.
 
 ## Add More Tooling
 
-<PackageManagerTabs command="npx servercn-cli add tooling commitlint husky eslint prettier lint-staged typescript " />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling commitlint husky eslint prettier lint-staged typescript " />

--- a/apps/web/src/content/docs/tooling/lint-staged.mdx
+++ b/apps/web/src/content/docs/tooling/lint-staged.mdx
@@ -1,7 +1,7 @@
 ---
 title: Lint-Staged
 description: A robust Lint-Staged configuration for TypeScript and Express.js projects.
-command: npx servercn-cli add tooling lint-staged
+command: npx servercn-cli@latest add tooling lint-staged
 ---
 
 # Lint-Staged
@@ -14,7 +14,7 @@ Lint-Staged runs linters only on staged Git files, ensuring that bad code never 
 
 Install Lint-Staged using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add tooling lint-staged" />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling lint-staged" />
 
 ## Configuration
 
@@ -100,4 +100,4 @@ Instead of <Code children="package.json" />, you can define your rules in <Code 
 
 ## Add More Tooling
 
-<PackageManagerTabs command="npx servercn-cli add tooling commitlint husky eslint prettier lint-staged typescript " />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling commitlint husky eslint prettier lint-staged typescript " />

--- a/apps/web/src/content/docs/tooling/prettier.mdx
+++ b/apps/web/src/content/docs/tooling/prettier.mdx
@@ -1,7 +1,7 @@
 ---
 title: Prettier
 description: A robust Prettier configuration for TypeScript and Express.js projects.
-command: npx servercn-cli add tooling prettier
+command: npx servercn-cli@latest add tooling prettier
 ---
 
 # Prettier
@@ -14,7 +14,7 @@ Prettier is an opinionated code formatter. It enforces a consistent style by par
 
 Install the Prettier configuration using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add tooling prettier" />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling prettier" />
 
 ## Configuration
 
@@ -55,4 +55,4 @@ Add the following scripts to your <Code children="package.json" />:
 
 ## Add More Tooling
 
-<PackageManagerTabs command="npx servercn-cli add tooling commitlint husky eslint prettier lint-staged typescript " />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling commitlint husky eslint prettier lint-staged typescript " />

--- a/apps/web/src/content/docs/tooling/typescript.mdx
+++ b/apps/web/src/content/docs/tooling/typescript.mdx
@@ -1,7 +1,7 @@
 ---
 title: TypeScript
 description: A robust TypeScript configuration for Node.js and Express.js projects.
-command: npx servercn-cli add tooling typescript
+command: npx servercn-cli@latest add tooling typescript
 ---
 
 # TypeScript
@@ -14,7 +14,7 @@ TypeScript is a strongly typed programming language that builds on JavaScript, g
 
 Install the TypeScript configuration using the Servercn CLI:
 
-<PackageManagerTabs command="npx servercn-cli add tooling typescript" />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling typescript" />
 
 ## Configuration
 
@@ -141,4 +141,4 @@ Then update your scripts:
 
 ## Add More Tooling
 
-<PackageManagerTabs command="npx servercn-cli add tooling commitlint husky eslint prettier lint-staged typescript " />
+<PackageManagerTabs command="npx servercn-cli@latest add tooling commitlint husky eslint prettier lint-staged typescript " />

--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -305,7 +305,10 @@
       "type": "component",
       "status": "stable",
       "frameworks": ["express", "nextjs"],
-      "docs": "/docs/components/rate-limiter"
+      "docs": "/docs/components/rate-limiter",
+      "meta": {
+        "new": true
+      }
     },
     {
       "slug": "github-google-oauth",

--- a/apps/web/src/lib/themes.ts
+++ b/apps/web/src/lib/themes.ts
@@ -37,10 +37,10 @@ export const CODE_THEMES: ITheme[] = [
     label: "Vitesse Dark",
     value: "vitesse-dark"
   },
-  {
-    label: "Vitesse Black",
-    value: "vitesse-black"
-  },
+  // {
+  //   label: "Vitesse Black",
+  //   value: "vitesse-black"
+  // },
   {
     label: "Vesper(Default)",
     value: "vesper",
@@ -83,35 +83,36 @@ export const CODE_THEMES: ITheme[] = [
     favorite: true
   },
   {
-    label: "Gruvbox Dark Hard",
+    label: "Gruvbox Dark",
     value: "gruvbox-dark-hard"
   },
   {
     label: "Material Theme",
-    value: "material-theme"
+    value: "material-theme",
+    favorite: true
   },
   {
     label: "Monokai",
     value: "monokai",
     favorite: true
   },
-  {
-    label: "Material Theme Darker",
-    value: "material-theme-darker",
-    favorite: true
-  },
-  {
-    label: "Material Theme Ocean",
-    value: "material-theme-ocean",
-    favorite: true
-  },
+  // {
+  //   label: "Material Theme Darker",
+  //   value: "material-theme-darker",
+  //   favorite: true
+  // },
+  // {
+  //   label: "Material Theme Ocean",
+  //   value: "material-theme-ocean",
+  //   favorite: true
+  // },
   {
     label: "GitHub Dark",
     value: "github-dark-default",
     favorite: true
   },
   {
-    label: "GitHub Light Default",
+    label: "GitHub Light",
     value: "github-light-default",
     light: true
   },
@@ -132,23 +133,22 @@ export const CODE_THEMES: ITheme[] = [
     value: "min-dark",
     favorite: true
   },
-
-  {
-    label: "GitHub Dark High Contrast",
-    value: "github-dark-high-contrast"
-  },
-  {
-    label: "Slack Dark",
-    value: "slack-dark"
-  },
+  // {
+  //   label: "GitHub Dark High Contrast",
+  //   value: "github-dark-high-contrast"
+  // },
+  // {
+  //   label: "Slack Dark",
+  //   value: "slack-dark"
+  // },
   {
     label: "Rose Pine Moon",
     value: "rose-pine-moon"
   },
-  {
-    label: "Rose Pine",
-    value: "rose-pine"
-  },
+  // {
+  //   label: "Rose Pine",
+  //   value: "rose-pine"
+  // },
   {
     label: "Dark Plus",
     value: "dark-plus"
@@ -161,10 +161,10 @@ export const CODE_THEMES: ITheme[] = [
     label: "Night Owl",
     value: "night-owl"
   },
-  {
-    label: "Catppuccin Mocha",
-    value: "catppuccin-mocha"
-  },
+  // {
+  //   label: "Catppuccin Mocha",
+  //   value: "catppuccin-mocha"
+  // },
   {
     label: "Catppuccin Macchiato",
     value: "catppuccin-macchiato"


### PR DESCRIPTION
Update every occurrence of `npx servercn-cli add` to `npx servercn-cli@latest add` across all documentation files, READMEs, and component previews to ensure users install the latest version of the CLI. Additionally, add the `meta: { new: true }` field to the rate-limiter component entry in the registry to mark it as a newly added component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples throughout documentation, including README, component guides, provider documentation, and schema guides
  * Modified installation instructions across Express, Next.js, and tooling component pages

* **Chores**
  * Added new designation to `rate-limiter` component in the registry
  * Updated available code syntax highlighting theme options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->