### PR TITLE
fix(cli): add @latest tag to all cli commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,13 +21,13 @@ npx servercn-cli init
 Add specific modules to your existing project. This allows for incremental adoption.
 
 ```bash
-npx servercn-cli add [component-name]
+npx servercn-cli@latest add [component-name]
 ```
 
 Add multiple components like this:
 
 ```bash
-npx servercn-cli add logger jwt-utils
+npx servercn-cli@latest add logger jwt-utils
 ```
 
 Visit [Servercn](https://servercn.vercel.app) for more information.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -65,20 +65,20 @@ Aliases:
   pr → provider
 
 Commands:
-  $ npx servercn-cli add <component-name>
+  $ npx servercn-cli@latest add <component-name>
   $ npx servercn-cli init <foundation-name>
-  $ npx servercn-cli add tooling <tooling-name>
-  $ npx servercn-cli add pr <provider-name>
-  $ npx servercn-cli add sc <schema-name>
-  $ npx servercn-cli add bp <blueprint-name>
+  $ npx servercn-cli@latest add tooling <tooling-name>
+  $ npx servercn-cli@latest add pr <provider-name>
+  $ npx servercn-cli@latest add sc <schema-name>
+  $ npx servercn-cli@latest add bp <blueprint-name>
 
 Examples:
-  $ npx servercn-cli add oauth
+  $ npx servercn-cli@latest add oauth
   $ npx servercn-cli init express-starter
-  $ npx servercn-cli add tl prettier
-  $ npx servercn-cli add pr mongodb-prisma
-  $ npx servercn-cli add sc auth
-  $ npx servercn-cli add bp stateless-auth
+  $ npx servercn-cli@latest add tl prettier
+  $ npx servercn-cli@latest add pr mongodb-prisma
+  $ npx servercn-cli@latest add sc auth
+  $ npx servercn-cli@latest add bp stateless-auth
 `
     )
     .action(

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -96,7 +96,7 @@ export async function init(foundation?: string, options: AddOptions = {}) {
     logger.break();
     logger.warn(`${APP_NAME} is already initialized in this project.`);
     logger.info(
-      "You can now add components: npx servercn-cli add <component-name>"
+      "You can now add components: npx servercn-cli@latest add <component-name>"
     );
     logger.break();
     process.exit(1);
@@ -562,13 +562,13 @@ export async function init(foundation?: string, options: AddOptions = {}) {
 
   logger.log("You may now add components by running:");
   if (response.root === ".") {
-    logger.muted("1. npx servercn-cli add <component>");
+    logger.muted("1. npx servercn-cli@latest add <component>");
   } else {
     logger.muted(`1. cd ${response.root}`);
-    logger.muted("2. npx servercn-cli add <component>");
+    logger.muted("2. npx servercn-cli@latest add <component>");
   }
   logger.muted(
-    "ex: npx servercn-cli add jwt-utils error-handler http-status-codes"
+    "ex: npx servercn-cli@latest add jwt-utils error-handler http-status-codes"
   );
   logger.break();
 }

--- a/packages/cli/src/commands/list/list.handlers.ts
+++ b/packages/cli/src/commands/list/list.handlers.ts
@@ -143,11 +143,11 @@ export async function listComponents(options: listOptionType) {
   );
   const data = {
     type: "component",
-    command: `npx servercn-cli add <component-name>`,
+    command: `npx servercn-cli@latest add <component-name>`,
     total: components.length,
     items: components.map(c => ({
       name: c.slug,
-      command: `npx servercn-cli add ${c.slug}`,
+      command: `npx servercn-cli@latest add ${c.slug}`,
       ...(c?.frameworks &&
         c.frameworks.length > 0 && { framework: c.frameworks })
     })),
@@ -175,7 +175,7 @@ export async function listComponents(options: listOptionType) {
     table.push([
       i + 1,
       c.slug,
-      `npx servercn-cli add ${c.slug}`,
+      `npx servercn-cli@latest add ${c.slug}`,
       (c?.frameworks && c.frameworks.join(", ")) || ""
     ]);
   });
@@ -244,13 +244,13 @@ export async function listProviders(options: listOptionType) {
 
   const data = {
     type: "provider",
-    command: `npx servercn-cli add pr <provider-name>`,
+    command: `npx servercn-cli@latest add pr <provider-name>`,
     total: foundations.length,
     items: foundations
       .sort((a, b) => a.slug.localeCompare(b.slug))
       .map(c => ({
         name: c.slug,
-        command: `npx servercn-cli add pr ${c.slug}`,
+        command: `npx servercn-cli@latest add pr ${c.slug}`,
         ...(c?.frameworks &&
           c.frameworks.length > 0 && { frameworks: c.frameworks })
       })),
@@ -279,7 +279,7 @@ export async function listProviders(options: listOptionType) {
     table.push([
       i + 1,
       c.slug,
-      `npx servercn-cli add pr ${c.slug}`,
+      `npx servercn-cli@latest add pr ${c.slug}`,
       (c?.frameworks && c.frameworks.join(", ")) || ""
     ]);
   });
@@ -297,11 +297,11 @@ export async function listTooling(options: listOptionType) {
   const data = {
     type: "tooling",
     alias: "tl",
-    command: `npx servercn-cli add tooling <tooling-name>`,
+    command: `npx servercn-cli@latest add tooling <tooling-name>`,
     total: toolings.length,
     items: toolings.map(c => ({
       name: c.slug,
-      command: `npx servercn-cli add tl ${c.slug}`
+      command: `npx servercn-cli@latest add tl ${c.slug}`
     })),
     docs: [`${SERVERCN_URL}/docs`, `${SERVERCN_URL}/docs/cli#ls-tl`]
   } satisfies listRegistryDataType;
@@ -324,7 +324,7 @@ export async function listTooling(options: listOptionType) {
   logger.break();
   logger.log(highlighter.create("Available Tooling"));
   toolings.map((c, i) => {
-    table.push([i + 1, c.slug, `npx servercn-cli add tl ${c.slug}`]);
+    table.push([i + 1, c.slug, `npx servercn-cli@latest add tl ${c.slug}`]);
   });
   logger.log(table.toString());
   logger.break();
@@ -340,13 +340,13 @@ export async function listSchemas(options: listOptionType) {
   const data = {
     type: "schema",
     alias: "sc",
-    command: `npx servercn-cli add schema <schema-name>`,
+    command: `npx servercn-cli@latest add schema <schema-name>`,
     total: schemas.length,
     items: schemas
       .sort((a, b) => a.slug.localeCompare(b.slug))
       .map(c => ({
         name: c.slug,
-        command: `npx servercn-cli add sc ${c.slug}`,
+        command: `npx servercn-cli@latest add sc ${c.slug}`,
         ...(c?.frameworks &&
           c.frameworks.length > 0 && { frameworks: c.frameworks })
       })),
@@ -375,7 +375,7 @@ export async function listSchemas(options: listOptionType) {
     table.push([
       i + 1,
       c.slug,
-      `npx servercn-cli add sc ${c.slug}`,
+      `npx servercn-cli@latest add sc ${c.slug}`,
       (c?.frameworks && c.frameworks.join(", ")) || ""
     ]);
   });
@@ -393,11 +393,11 @@ export async function listBlueprints(options: listOptionType) {
   const data = {
     type: "blueprint",
     alias: "bp",
-    command: `npx servercn-cli add blueprint <blueprint-name>`,
+    command: `npx servercn-cli@latest add blueprint <blueprint-name>`,
     total: blueprints.length,
     items: blueprints.map(c => ({
       name: c.slug,
-      command: `npx servercn-cli add bp ${c.slug}`,
+      command: `npx servercn-cli@latest add bp ${c.slug}`,
       ...(c?.frameworks &&
         c.frameworks.length > 0 && { frameworks: c.frameworks })
     })),
@@ -426,7 +426,7 @@ export async function listBlueprints(options: listOptionType) {
     table.push([
       i + 1,
       c.slug,
-      `npx servercn-cli add bp ${c.slug}`,
+      `npx servercn-cli@latest add bp ${c.slug}`,
       (c?.frameworks && c.frameworks.join(", ")) || ""
     ]);
   });

--- a/packages/cli/src/commands/view/view.handlers.ts
+++ b/packages/cli/src/commands/view/view.handlers.ts
@@ -79,10 +79,10 @@ async function readLocalTemplateFiles(
 
 function installationCommand(type: RegistryType, name: string) {
   if (type === "foundation") return `npx servercn-cli init ${name}`;
-  if (type === "tooling") return `npx servercn-cli add tl ${name}`;
-  if (type === "schema") return `npx servercn-cli add sc ${name}`;
-  if (type === "blueprint") return `npx servercn-cli add bp ${name}`;
-  return `npx servercn-cli add ${name}`;
+  if (type === "tooling") return `npx servercn-cli@latest add tl ${name}`;
+  if (type === "schema") return `npx servercn-cli@latest add sc ${name}`;
+  if (type === "blueprint") return `npx servercn-cli@latest add bp ${name}`;
+  return `npx servercn-cli@latest add ${name}`;
 }
 
 function renderOverview(rows: Array<[string, string]>) {


### PR DESCRIPTION
Update all instances of `npx servercn-cli add` to include the @latest tag across documentation, help text, and code-generated command outputs, ensuring users always pull the latest CLI version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI documentation and help text to consistently display the `@latest` version specifier in all command examples. This affects the README file, command help text for add and init operations, component and schema listings, and installation guidance. Users will now see standardized command formats throughout the CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->