### PR TITLE
feat(web): add changelog page and navigation links

### DIFF
--- a/apps/web/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/docs/[[...slug]]/page.tsx
@@ -67,10 +67,23 @@ export async function generateStaticParams() {
     { slug: [] },
     { slug: ["introduction"] },
     { slug: ["cli"] },
-    { slug: ["installation"] }
+    { slug: ["installation"] },
+    { slug: ["changelog"] }
   ];
 
-  return [...specialRoutes, ...registryParams, ...contributingParams];
+  const changelogPaths = fs
+    .readdirSync(path.join(DOCS_PATH, "changelog"))
+    .filter(file => file.endsWith(".mdx") && file !== "index.mdx")
+    .map(file => ({
+      slug: ["changelog", file.replace(".mdx", "")]
+    }));
+
+  return [
+    ...specialRoutes,
+    ...registryParams,
+    ...contributingParams,
+    ...changelogPaths
+  ];
 }
 
 export async function generateMetadata(props: {
@@ -132,6 +145,13 @@ function getDocPath(slug?: string[]) {
   }
 
   const actualSlug = slug;
+
+  if (actualSlug.length >= 1 && actualSlug[0] === "changelog") {
+    if (actualSlug.length === 1) {
+      return path.join(DOCS_PATH, "changelog", "index.mdx");
+    }
+    return path.join(DOCS_PATH, `${actualSlug.join("/")}.mdx`);
+  }
 
   if (actualSlug.length === 2 && actualSlug[0] === "contributing") {
     return path.join(DOCS_PATH, `${actualSlug.join("/")}.mdx`);
@@ -200,7 +220,6 @@ export default async function DocsPage({
     // variant
   } = resolveRegistryItem(slug[slug.length - 1]);
 
-
   return (
     <>
       <FrameworkRedirect />
@@ -215,7 +234,8 @@ export default async function DocsPage({
                   "guides",
                   "installation",
                   "introduction",
-                  "contributing"
+                  "contributing",
+                  "changelog",
                 ].includes(slug[0]) && (
                   <ViewAsJson
                     type={

--- a/apps/web/src/components/docs/mdx-components.tsx
+++ b/apps/web/src/components/docs/mdx-components.tsx
@@ -14,6 +14,7 @@ import { getIconForLanguageExtension } from "./icons/language-icons";
 import { Table, THead, TBody, TR, TH, TD } from "./table";
 import { Method, Endpoint, Auth } from "./api-table";
 import { JSGuideVideo } from "@/components/home/js-guide-video";
+import ComponentFileViewer from "@/components/file-viewer";
 
 export const mdxComponents: MDXComponents = {
   pre: Pre,
@@ -25,6 +26,7 @@ export const mdxComponents: MDXComponents = {
   LNote,
   Warning,
   JSGuideVideo,
+  ComponentFileViewer,
 
   Table,
   THead,

--- a/apps/web/src/components/layouts/docs-sidebar.tsx
+++ b/apps/web/src/components/layouts/docs-sidebar.tsx
@@ -72,6 +72,10 @@ export const PAGE_ITEMS = [
   {
     title: "llms.txt",
     url: "/llms.txt"
+  },
+  {
+    title: "Changelog",
+    url: "/docs/changelog"
   }
 ];
 

--- a/apps/web/src/lib/config.ts
+++ b/apps/web/src/lib/config.ts
@@ -39,6 +39,10 @@ export const siteConfig = {
     {
       label: "Contributors",
       href: "/contributors"
+    },
+    {
+      label: "Changelog",
+      href: "/docs/changelog"
     }
   ],
 


### PR DESCRIPTION
Add changelog nav items to site header and docs sidebar, implement static params and routing for changelog docs, and register required MDX component.