### PR TITLE
docs: add new links and component docs to llms.txt

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -28,6 +28,8 @@
 - [Schemas](https://www.servercn.xyz/schemas)
 - [Contributing Guides](https://www.servercn.xyz/contributing)
 - [Contributors](https://www.servercn.xyz/contributors)
+- [llms.txt](https://www.servercn.xyz/llms.txt)
+- [Changelog](https://www.servercn.xyz/docs/changelog)
 
 
 ## Frameworks
@@ -131,6 +133,8 @@
 - [Request Validator (Zod)](https://www.servercn.xyz/docs/nextjs/components/request-validator): type-safe request validation utility built on top of zod.
 - [Logger](https://www.servercn.xyz/docs/nextjs/components/logger):  a foundational requirement for debugging, monitoring, and operating production-grade backend systems.
 - [Generate OTP/Token Helper Functions](https://www.servercn.xyz/docs/nextjs/components/generate-otp-token): cryptographically secure utility functions for generating OTPs, random tokens, and unique identifiers for authentication workflows.
+- [File Upload (Cloudinary)](https://www.servercn.xyz/docs/nextjs/components/file-upload-cloudinary): omponent provides a standardized way to handle file uploads in Servercn using Cloudinary as the storage provider.
+- [File Upload (Imagekit)](https://www.servercn.xyz/docs/nextjs/components/file-upload-imagekit): omponent provides a standardized way to handle file uploads in Servercn using Imagekit as the storage provider.
 
 
 ## Blueprints


### PR DESCRIPTION
Add llms.txt and changelog navigation links, plus Cloudinary and Imagekit file upload component documentation entries to the public llms.txt index file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new documentation navigation links: `llms.txt` and `Changelog` to improve content discovery
  * Added two new file upload component options with Cloudinary and Imagekit integrations for flexible media management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->