### PR TITLE
docs(express): update env config snippets to use proper dotenv-flow s…

### DIFF
--- a/apps/web/src/content/docs/express/components/env-config.mdx
+++ b/apps/web/src/content/docs/express/components/env-config.mdx
@@ -20,7 +20,8 @@ Install the component using the servercn CLI:
 ## Basic Implementation
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/components/file-upload-cloudinary.mdx
+++ b/apps/web/src/content/docs/express/components/file-upload-cloudinary.mdx
@@ -54,7 +54,8 @@ CLOUDINARY_API_SECRET="your-api-secret"
 Ensure the following configuration is defined:
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({
@@ -305,7 +306,8 @@ export default router;
 
 ```ts title="src/app.ts" {7, 19}
 import express, { Application } from "express";
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 
 import { errorHandler } from "./middlewares/error-handler";
 import { logger } from "./utils/logger";

--- a/apps/web/src/content/docs/express/components/file-upload-imagekit.mdx
+++ b/apps/web/src/content/docs/express/components/file-upload-imagekit.mdx
@@ -37,7 +37,8 @@ The CLI will then automatically configure the component based on your selected p
 You must have an ImageKit account. Click [here](https://imagekit.io) if you don't have one.
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({
@@ -284,7 +285,8 @@ export default router;
 
 ```ts title="src/app.ts" {7, 19}
 import express, { Application } from "express";
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 
 import { errorHandler } from "./middlewares/error-handler";
 import { logger } from "./utils/logger";

--- a/apps/web/src/content/docs/express/components/github-oauth.mdx
+++ b/apps/web/src/content/docs/express/components/github-oauth.mdx
@@ -57,7 +57,8 @@ GITHUB_REDIRECT_URI="your-github-redirectUri"
 ```
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 
 interface Config {
   PORT: number;

--- a/apps/web/src/content/docs/express/components/global-error-handler.mdx
+++ b/apps/web/src/content/docs/express/components/global-error-handler.mdx
@@ -91,7 +91,8 @@ export const errorHandler = (
 
 ```ts title="src/app.ts" { 13 }
 import express, { type Application } from "express";
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { errorHandler } from "./middlewares/error-handler";
 
 const app: Application = express();

--- a/apps/web/src/content/docs/express/components/google-oauth.mdx
+++ b/apps/web/src/content/docs/express/components/google-oauth.mdx
@@ -63,7 +63,8 @@ GOOGLE_REDIRECT_URI="http://localhost:9000/api/auth/google/callback"
 Ensure the following configuration are defined:
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 
 interface Config {
   PORT: number;

--- a/apps/web/src/content/docs/express/components/jwt-utils.mdx
+++ b/apps/web/src/content/docs/express/components/jwt-utils.mdx
@@ -34,7 +34,8 @@ must be different and kept private
 
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/cloudinary-storage.mdx
+++ b/apps/web/src/content/docs/express/providers/cloudinary-storage.mdx
@@ -21,7 +21,8 @@ This provider adds [Cloudinary](https://cloudinary.com/) SDK configuration, Zod-
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/imagekit-storage.mdx
+++ b/apps/web/src/content/docs/express/providers/imagekit-storage.mdx
@@ -21,7 +21,8 @@ This provider adds the [ImageKit Node SDK](https://github.com/imagekit-developer
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/mongodb-mongoose.mdx
+++ b/apps/web/src/content/docs/express/providers/mongodb-mongoose.mdx
@@ -21,7 +21,8 @@ This provider sets up MongoDB connectivity with Mongoose for Express projects, i
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/mongodb-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/mongodb-prisma.mdx
@@ -21,7 +21,8 @@ This provider sets up MongoDB connectivity with Prisma for Express projects, inc
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/mysql-drizzle.mdx
+++ b/apps/web/src/content/docs/express/providers/mysql-drizzle.mdx
@@ -21,7 +21,8 @@ This provider sets up MySQL connectivity with Drizzle ORM for Express projects, 
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/mysql-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/mysql-prisma.mdx
@@ -21,7 +21,8 @@ This provider sets up MySQL connectivity with Prisma for Express projects, inclu
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/nodemailer-smtp.mdx
+++ b/apps/web/src/content/docs/express/providers/nodemailer-smtp.mdx
@@ -20,7 +20,8 @@ This provider configures [Nodemailer](https://nodemailer.com/) with SMTP setting
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/pg-drizzle-neon.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-drizzle-neon.mdx
@@ -21,7 +21,8 @@ This provider sets up PostgreSQL + Neon connectivity with Drizzle ORM for Expres
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/pg-drizzle.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-drizzle.mdx
@@ -21,7 +21,8 @@ This provider sets up PostgreSQL connectivity with Drizzle ORM for Express proje
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/pg-prisma.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-prisma.mdx
@@ -21,7 +21,8 @@ This provider sets up PostgreSQL connectivity with Prisma for Express projects, 
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/redis.mdx
+++ b/apps/web/src/content/docs/express/providers/redis.mdx
@@ -21,7 +21,8 @@ This provider wires the official [redis](https://github.com/redis/node-redis) pa
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({

--- a/apps/web/src/content/docs/express/providers/resend-mail.mdx
+++ b/apps/web/src/content/docs/express/providers/resend-mail.mdx
@@ -21,7 +21,8 @@ This provider adds the official [Resend](https://resend.com/) SDK, validates <Co
 ### 1. Env Configuration
 
 ```ts title="src/configs/env.ts"
-import "dotenv-flow/config";
+import dotenv from "dotenv-flow";
+dotenv.config();
 import { z } from "zod";
 
 export const envSchema = z.object({


### PR DESCRIPTION
…etup

standardize environment configuration and app entry import examples across all Express documentation pages by replacing the shorthand `import "dotenv-flow/config"` with explicit import and config calls for better clarity and correctness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized environment variable initialization examples across Express documentation by updating code snippets to use explicit configuration calls instead of implicit module imports for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->