### PR TITLE
docs(nextjs-docs): restructure component docs with tabbed install sections

### DIFF
--- a/apps/web/src/content/docs/nextjs/components/error-handler.mdx
+++ b/apps/web/src/content/docs/nextjs/components/error-handler.mdx
@@ -9,11 +9,120 @@ A standardized error handling utility for Next.js Route Handlers that ensures co
 
 ---
 
-## Installation Guide
+## Installation Guide 
 
-Install the component using the servercn CLI:
-
+<Tabs defaultValue="command">
+<TabsList>
+<TabsTrigger value="command">
+Command
+</TabsTrigger>
+<TabsTrigger value="manual">
+Manual
+</TabsTrigger>
+</TabsList>
+<TabsContent value="command">
 <PackageManagerTabs command="npx servercn-cli@latest add error-handler" />
+</TabsContent>
+
+<TabsContent value="manual">
+<Steps>
+<Step>Install Zod</Step>
+<PackageManagerTabs command="npm install zod" />
+
+<Step>Create the ApiError Class</Step>
+```ts title="src/utils/api-error.ts"
+import { STATUS_CODES, StatusCode } from "@/constants/status-codes";
+
+export class ApiError extends Error {
+  public readonly statusCode: StatusCode;
+  public readonly isOperational: boolean;
+  public readonly errors?: unknown;
+
+  constructor(
+    statusCode: StatusCode,
+    message: string,
+    errors?: unknown,
+    isOperational = true
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+    this.errors = errors;
+    this.isOperational = isOperational;
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+
+  static badRequest(message = "Bad Request", errors?: unknown) {
+    return new ApiError(STATUS_CODES.BAD_REQUEST, message, errors);
+  }
+
+  static unauthorized(message = "Unauthorized") {
+    return new ApiError(STATUS_CODES.UNAUTHORIZED, message);
+  }
+
+  static forbidden(message = "Forbidden") {
+    return new ApiError(STATUS_CODES.FORBIDDEN, message);
+  }
+
+  static notFound(message = "Not Found") {
+    return new ApiError(STATUS_CODES.NOT_FOUND, message);
+  }
+
+  static conflict(message = "Conflict") {
+    return new ApiError(STATUS_CODES.CONFLICT, message);
+  }
+
+  static server(message = "Internal Server Error") {
+    return new ApiError(STATUS_CODES.INTERNAL_SERVER_ERROR, message);
+  }
+}
+```
+
+<Step>Implement the Error Handler</Step>
+```ts title="src/utils/error-handler.ts"
+import z, { ZodError } from "zod";
+import { NextResponse } from "next/server";
+import { ApiError } from "@/utils/api-error";
+import { STATUS_CODES } from "@/constants/status-codes";
+import { logger } from "@/utils/logger";
+
+export function handleError(error: unknown) {
+  logger.error(error);
+  if (error instanceof ZodError) {
+    return ApiError.badRequest("Invalid request data", z.flattenError(error));
+  }
+
+  if (error instanceof ApiError) {
+    return NextResponse.json(
+      {
+        success: false,
+        message: error.message,
+        statusCode: error.statusCode,
+        ...(Array.isArray(error.errors) && { errors: error.errors }),
+        ...(process.env.NODE_ENV === "development" && { stack: error.stack })
+      },
+      { status: error.statusCode }
+    );
+  }
+
+  return NextResponse.json(
+    {
+      success: false,
+      message: "Internal Server Error",
+      statusCode: STATUS_CODES.INTERNAL_SERVER_ERROR
+    },
+    { status: STATUS_CODES.INTERNAL_SERVER_ERROR }
+  );
+}
+```
+
+</Steps>    
+</TabsContent>
+</Tabs>
+
 
 ---
 
@@ -117,106 +226,6 @@ export async function GET() {
       ]
     }
   }
-}
-```
-
-<br />
----
-
-## Basic Implementation
-
-### 1. <Code>ApiError</Code> Class
-
-```ts title="src/utils/api-error.ts"
-import { STATUS_CODES, StatusCode } from "@/constants/status-codes";
-
-export class ApiError extends Error {
-  public readonly statusCode: StatusCode;
-  public readonly isOperational: boolean;
-  public readonly errors?: unknown;
-
-  constructor(
-    statusCode: StatusCode,
-    message: string,
-    errors?: unknown,
-    isOperational = true
-  ) {
-    super(message);
-    this.name = "ApiError";
-    this.statusCode = statusCode;
-    this.errors = errors;
-    this.isOperational = isOperational;
-
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, this.constructor);
-    }
-  }
-
-  static badRequest(message = "Bad Request", errors?: unknown) {
-    return new ApiError(STATUS_CODES.BAD_REQUEST, message, errors);
-  }
-
-  static unauthorized(message = "Unauthorized") {
-    return new ApiError(STATUS_CODES.UNAUTHORIZED, message);
-  }
-
-  static forbidden(message = "Forbidden") {
-    return new ApiError(STATUS_CODES.FORBIDDEN, message);
-  }
-
-  static notFound(message = "Not Found") {
-    return new ApiError(STATUS_CODES.NOT_FOUND, message);
-  }
-
-  static conflict(message = "Conflict") {
-    return new ApiError(STATUS_CODES.CONFLICT, message);
-  }
-
-  static server(message = "Internal Server Error") {
-    return new ApiError(STATUS_CODES.INTERNAL_SERVER_ERROR, message);
-  }
-}
-```
-
----
-
-### 2. <Code>handleError</Code> Function
-
-
-```ts title="src/utils/error-handler.ts"
-import z, { ZodError } from "zod";
-import { NextResponse } from "next/server";
-import { ApiError } from "./api-error";
-import { STATUS_CODES } from "@/constants/status-codes";
-import { logger } from "./logger";
-
-export function handleError(error: unknown) {
-  logger.error(error);
-  if (error instanceof ZodError) {
-    return ApiError.badRequest("Invalid request data", z.flattenError(error));
-  }
-
-  if (error instanceof ApiError) {
-    return NextResponse.json(
-      {
-        success: false,
-        message: error.message,
-        statusCode: error.statusCode,
-        ...(Array.isArray(error.errors) && { errors: error.errors }),
-        ...(process.env.NODE_ENV === "development" && { stack: error.stack })
-      },
-      { status: error.statusCode }
-    );
-  }
-
-  return NextResponse.json(
-    {
-      success: false,
-      message: "Internal Server Error",
-      statusCode: STATUS_CODES.INTERNAL_SERVER_ERROR
-    },
-    { status: STATUS_CODES.INTERNAL_SERVER_ERROR }
-  );
 }
 ```
 

--- a/apps/web/src/content/docs/nextjs/components/response-formatter.mdx
+++ b/apps/web/src/content/docs/nextjs/components/response-formatter.mdx
@@ -7,14 +7,107 @@ command: npx servercn-cli@latest add response-formatter
 # API Response Formatter
 A standardized response formatter for Next.js Route Handlers that ensures consistent API responses across your application.
 
-
 ---
 
 ## Installation Guide
 
-Install the component using the servercn CLI:
-
+<Tabs defaultValue="command">
+<TabsList>
+<TabsTrigger value="command">
+Command
+</TabsTrigger>
+<TabsTrigger value="manual">
+Manual
+</TabsTrigger>
+</TabsList>
+<TabsContent value="command">
 <PackageManagerTabs command="npx servercn-cli@latest add response-formatter" />
+</TabsContent>
+
+<TabsContent value="manual">
+```ts title="src/utils/api-response.ts"
+import { NextResponse } from "next/server";
+import { STATUS_CODES, StatusCode } from "@/constants/status-codes";
+
+type ApiResponseParams<T> = {
+  success: boolean;
+  message: string;
+  statusCode: StatusCode;
+  data?: T | null;
+  errors?: unknown;
+};
+
+export class ApiResponse<T = unknown> {
+  public readonly success: boolean;
+  public readonly message: string;
+  public readonly statusCode: StatusCode;
+  public readonly data?: T | null;
+  public readonly errors?: unknown;
+
+  constructor({
+    success,
+    message,
+    statusCode,
+    data = null,
+    errors
+  }: ApiResponseParams<T>) {
+    this.success = success;
+    this.message = message;
+    this.statusCode = statusCode;
+    this.data = data;
+    this.errors = errors;
+  }
+
+  send(): NextResponse {
+    return NextResponse.json(
+      {
+        success: this.success,
+        message: this.message,
+        statusCode: this.statusCode,
+        ...(this.data !== undefined && { data: this.data }),
+        ...(this.errors !== undefined && { errors: this.errors })
+      },
+      { status: this.statusCode }
+    );
+  }
+
+  static success<T>(
+    message: string,
+    data?: T,
+    statusCode: StatusCode = STATUS_CODES.OK
+  ): NextResponse {
+    return new ApiResponse<T>({
+      success: true,
+      message,
+      data,
+      statusCode
+    }).send();
+  }
+
+  static ok<T>(message = "OK", data?: T) {
+    return ApiResponse.success(message, data, STATUS_CODES.OK);
+  }
+
+  static created<T>(message = "Created", data?: T) {
+    return ApiResponse.success(message, data, STATUS_CODES.CREATED);
+  }
+
+  static error(
+    message = "Error",
+    errors?: unknown,
+    statusCode: StatusCode = STATUS_CODES.INTERNAL_SERVER_ERROR
+  ) {
+    return new ApiResponse({
+      success: false,
+      message,
+      errors,
+      statusCode
+    }).send();
+  }
+}
+```
+</TabsContent>
+</Tabs>
 
 ---
 
@@ -97,103 +190,6 @@ export async function GET() {
      "name": "Servercn response-formatter component" 
   }
 }
-```
-
-<br />
----
-
-## Basic Implementation
-
-```ts title="src/utils/api-response.ts"
-import { NextResponse } from "next/server";
-import { STATUS_CODES, StatusCode } from "@/constants/status-codes";
-
-type ApiResponseParams<T> = {
-  success: boolean;
-  message: string;
-  statusCode: StatusCode;
-  data?: T | null;
-  errors?: unknown;
-};
-
-export class ApiResponse<T = unknown> {
-  public readonly success: boolean;
-  public readonly message: string;
-  public readonly statusCode: StatusCode;
-  public readonly data?: T | null;
-  public readonly errors?: unknown;
-
-  constructor({
-    success,
-    message,
-    statusCode,
-    data = null,
-    errors
-  }: ApiResponseParams<T>) {
-    this.success = success;
-    this.message = message;
-    this.statusCode = statusCode;
-    this.data = data;
-    this.errors = errors;
-  }
-
-  send(): NextResponse {
-    return NextResponse.json(
-      {
-        success: this.success,
-        message: this.message,
-        statusCode: this.statusCode,
-        ...(this.data !== undefined && { data: this.data }),
-        ...(this.errors !== undefined && { errors: this.errors })
-      },
-      { status: this.statusCode }
-    );
-  }
-
-  static success<T>(
-    message: string,
-    data?: T,
-    statusCode: StatusCode = STATUS_CODES.OK
-  ): NextResponse {
-    return new ApiResponse<T>({
-      success: true,
-      message,
-      data,
-      statusCode
-    }).send();
-  }
-
-  static ok<T>(message = "OK", data?: T) {
-    return ApiResponse.success(message, data, STATUS_CODES.OK);
-  }
-
-  static created<T>(message = "Created", data?: T) {
-    return ApiResponse.success(message, data, STATUS_CODES.CREATED);
-  }
-
-  static error(
-    message = "Error",
-    errors?: unknown,
-    statusCode: StatusCode = STATUS_CODES.INTERNAL_SERVER_ERROR
-  ) {
-    return new ApiResponse({
-      success: false,
-      message,
-      errors,
-      statusCode
-    }).send();
-  }
-}
-/**
- * ? Usage:
-import { ApiResponse } from "@/utils/api-response";
-
-export async function GET() {
-  const data = { name: "Akkal" };
-
-  return ApiResponse.ok("Fetched successfully", data);
-}
-*/
 ```
 
 <br />


### PR DESCRIPTION


Update response-formatter.mdx and error-handler.mdx to replace plain installation instructions with tabbed Command/Manual installation guides, reorganize content flow, and move manual installation code snippets into the dedicated manual tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized and expanded the error handling guide with tabbed CLI and manual installation options, including complete code examples.
  * Updated response formatter documentation with tabbed installation instructions (command vs. manual) and refined code examples.
  * Improved overall structure and content presentation for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->