### PR TITLE
docs(changelog): add 2026-06-20 rate limiter entry

### DIFF
--- a/apps/web/src/content/docs/changelog/index.mdx
+++ b/apps/web/src/content/docs/changelog/index.mdx
@@ -9,6 +9,19 @@ Latest updates and announcements.
 
 ## June 2026
 
+#### 20 June, 2026 - Express.js Rate Limiter Component
+
+- Added <Code>upstash</Code> and <Code>ioredis</Code> variants for the Rate Limiter component.
+- Expanded the component beyond the existing <Code>express-rate-limit</Code> implementation.
+
+<PackageManagerTabs command="npx servercn-cli@latest add rate-limiter" />
+
+[Read more](/docs/express/components/rate-limiter)
+
+<br />
+---
+<br />
+
 #### 18 June, 2026 - Next.js File Upload Component(Imagekit)
 
 


### PR DESCRIPTION
add the changelog entry for the new upstash and ioredis rate limiter variants, including install command and docs link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with new entry for the Express.js Rate Limiter Component, documenting new `upstash` and `ioredis` variants and expanded functionality. Added installation instructions and links to relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->