### PR TITLE
feat(registry mongodb-mongoose): add nextjs support

### DIFF
--- a/apps/web/public/sr/index.json
+++ b/apps/web/public/sr/index.json
@@ -395,7 +395,8 @@
       "type": "provider",
       "slug": "mongodb-mongoose",
       "frameworks": [
-        "express"
+        "express",
+        "nextjs"
       ]
     },
     {

--- a/apps/web/public/sr/provider/mongodb-mongoose.json
+++ b/apps/web/public/sr/provider/mongodb-mongoose.json
@@ -43,6 +43,33 @@
               ]
             }
           }
+        },
+        "nextjs": {
+          "dependencies": {
+            "runtime": [
+              "mongoose"
+            ],
+            "dev": []
+          },
+          "env": [
+            "DATABASE_URL"
+          ],
+          "architectures": {
+            "file-api": {
+              "files": [
+                {
+                  "type": "file",
+                  "path": "src/types/global.d.ts",
+                  "content": "import { Connection } from \"mongoose\";\r\n\r\ndeclare global {\r\n  var mongooseCache:\r\n    | {\r\n        conn: Connection | null;\r\n        promise: Promise<Connection> | null;\r\n      }\r\n    | undefined;\r\n}\r\n\r\nexport {};\r\n"
+                },
+                {
+                  "type": "file",
+                  "path": "src/configs/db.ts",
+                  "content": "import mongoose, { Connection } from \"mongoose\";\r\n\r\nconst MONGODB_URI = process.env.DATABASE_URL!;\r\n\r\nif (!MONGODB_URI) {\r\n  throw new Error(\"Missing MONGODB_URI environment variable\");\r\n}\r\n\r\nconst globalCache = global.mongooseCache ?? {\r\n  conn: null,\r\n  promise: null\r\n};\r\n\r\nglobal.mongooseCache = globalCache;\r\n\r\nexport async function dbConnect(): Promise<Connection> {\r\n  if (globalCache.conn) {\r\n    return globalCache.conn;\r\n  }\r\n\r\n  if (!globalCache.promise) {\r\n    globalCache.promise = mongoose.connect(MONGODB_URI).then(m => m.connection);\r\n  }\r\n\r\n  try {\r\n    globalCache.conn = await globalCache.promise;\r\n  } catch (error) {\r\n    console.error(\"❌ Error connecting to MongoDB:\", error);\r\n    globalCache.promise = null;\r\n    throw error;\r\n  }\r\n\r\n  console.log(\"✅ MongoDB connected\");\r\n  return globalCache.conn;\r\n}"
+                }
+              ]
+            }
+          }
         }
       }
     }

--- a/apps/web/src/components/docs/component-card.tsx
+++ b/apps/web/src/components/docs/component-card.tsx
@@ -8,7 +8,7 @@ export default function ComponentCard({
 }: {
   component: IRegistryItems;
 }) {
-  const isStable = ["stable", "deprecated"].includes(component.status);
+  const isStable = ["stable"].includes(component.status);
 
   return (
     <Link

--- a/apps/web/src/components/docs/components-catalog.tsx
+++ b/apps/web/src/components/docs/components-catalog.tsx
@@ -19,7 +19,7 @@ export function ComponentsCatalog({ type }: { type: ItemType }) {
     <>
       <div className="screen-line-after &>*]:border grid divide-x sm:grid-cols-2 lg:grid-cols-3 [&>*:nth-child(3n)]:border-r-0 [&>*:nth-child(3n+1)]:border-l-0">
         {components
-          .filter(c => c.status !== "experimental")
+          .filter(c => !["experimental", "deprecated"].includes(c.status))
           .map(component =>
             ["blueprint", "schema"].includes(type) ? (
               <ItemWithDBCard key={component.slug} item={component} />

--- a/packages/registry/provider/mongodb-mongoose.json
+++ b/packages/registry/provider/mongodb-mongoose.json
@@ -14,6 +14,16 @@
             "dev": []
           },
           "env": ["DATABASE_URL"]
+        },
+        "nextjs": {
+          "templates": {
+            "file-api": "mongodb-mongoose/file-api"
+          },
+          "dependencies": {
+            "runtime": ["mongoose"],
+            "dev": []
+          },
+          "env": ["DATABASE_URL"]
         }
       }
     }


### PR DESCRIPTION
add nextjs framework configuration and associated template files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Next.js support for the MongoDB Mongoose starter/configuration, including a ready-to-use database connection setup.
  * Expanded the component catalog to better surface supported items by excluding deprecated and experimental entries.
* **Bug Fixes**
  * Updated component cards so only fully stable components are shown as available, preventing users from opening non-stable entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->