### PR TITLE
feat: add nextjs support for mongodb-mongoose

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -173,6 +173,12 @@
 - [Redis](https://www.servercn.xyz/docs/express/providers/redis): wires the official redis package to REDIS_URL, validates the URL with Zod, and includes small setCache / getCache / deleteCache helpers.
 - [Resend Mail](https://www.servercn.xyz/docs/express/providers/resend-mail): adds the official Resend SDK, validates RESEND_API_KEY with Zod, and exports a ready-to-use resend client.
 
+### Next.js
+
+- [Mongodb(Mongoose)](https://www.servercn.xyz/docs/nextjs/providers/mongodb-mongoose): sets up MongoDB connectivity with Mongoose for nextjs projects, including database connection.
+
+
+- [Mongodb(Mongoose)](https://www.servercn.xyz/docs/express/providers/mongodb-mongoose): sets up MongoDB connectivity with Mongoose for Express projects, including environment validation, a database connection helper.
 
 ## Schemas
 

--- a/apps/web/src/content/docs/nextjs/providers/mongodb-mongoose.mdx
+++ b/apps/web/src/content/docs/nextjs/providers/mongodb-mongoose.mdx
@@ -1,0 +1,99 @@
+---
+title: Mongodb(Mongoose) | Provider | Next.js
+description: MongoDB provider with Mongoose ORM for nextjs applications.
+command: npx servercn-cli@latest add pr mongodb-mongoose
+---
+
+# Mongodb(Mongoose) Provider
+
+This provider sets up MongoDB connectivity with Mongoose for nextjs projects, including database connection.
+
+---
+
+## Installation Guide
+
+<Tabs defaultValue="command">
+<TabsList>
+<TabsTrigger value="command">
+Command
+</TabsTrigger>
+<TabsTrigger value="manual">
+Manual
+</TabsTrigger>
+</TabsList>
+<TabsContent value="command">
+<PackageManagerTabs command="npx servercn-cli@latest add pr mongodb-mongoose" />
+</TabsContent>    
+<TabsContent value="manual">
+<Steps>
+<Step>Install Dependencies:</Step>
+<PackageManagerTabs command="npm install mongoose" />
+
+<Step>Create Global Mongoose Types</Step>
+```ts title="src/types/global.d.ts"
+import { Connection } from "mongoose";
+
+declare global {
+  var mongooseCache:
+    | {
+      conn: Connection | null;
+        promise: Promise<Connection> | null;
+      }
+    | undefined;
+}
+
+export {};
+```
+
+<Step>Create MongoDB Connection Utility</Step>
+```ts title="src/configs/db.ts"
+import mongoose, { Connection } from "mongoose";
+
+const MONGODB_URI = process.env.DATABASE_URL!;
+
+if (!MONGODB_URI) {
+  throw new Error("Missing MONGODB_URI environment variable");
+}
+
+const globalCache = global.mongooseCache ?? {
+  conn: null,
+  promise: null
+};
+
+global.mongooseCache = globalCache;
+
+export async function dbConnect(): Promise<Connection> {
+  if (globalCache.conn) {
+    return globalCache.conn;
+  }
+
+  if (!globalCache.promise) {
+    globalCache.promise = mongoose.connect(MONGODB_URI).then(m => m.connection);
+  }
+
+  try {
+    globalCache.conn = await globalCache.promise;
+  } catch (error) {
+    console.error("❌ Error connecting to MongoDB:", error);
+    globalCache.promise = null;
+    throw error;
+  }
+
+  console.log("✅ MongoDB connected");
+  return globalCache.conn;
+}
+```
+</Steps>    
+</TabsContent>    
+</Tabs>
+
+
+---
+
+## Usage Example
+
+```ts
+import { dbConnect } from "@/configs/db";
+
+await dbConnect();
+```

--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -713,9 +713,9 @@
       "slug": "mongodb-mongoose",
       "type": "provider",
       "status": "stable",
-      "frameworks": ["express"],
+      "frameworks": ["express", "nextjs"],
       "title": "MongoDB (Mongoose)",
-      "description": "MongoDB provider with Mongoose ORM for Express applications.",
+      "description": "MongoDB provider with Mongoose ORM for express & nextjs applications.",
       "docs": "/docs/providers/mongodb-mongoose",
       "meta": {
         "new": true


### PR DESCRIPTION
Update the provider registry to include nextjs as a supported framework, and add dedicated Next.js documentation for the mongodb-mongoose provider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Next.js guide for connecting to MongoDB with Mongoose.
  * Expanded the providers list to include a Next.js-specific MongoDB/Mongoose option.
  * Updated the provider catalog so this setup is now shown for both Express and Next.js projects.

* **Documentation**
  * Included setup steps, connection reuse guidance, and a usage example for the new Next.js database connection flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->