### PR TITLE
docs(changelog): add next.js provider entries

### DIFF
--- a/apps/web/src/content/docs/changelog/index.mdx
+++ b/apps/web/src/content/docs/changelog/index.mdx
@@ -9,6 +9,30 @@ Latest updates and announcements.
 
 ## June 2026
 
+#### 26 June, 2026 - Next.js MySQL(Drizzle) Provider
+
+- Added the <Code>mysql-drizzle</Code> provider for Next.js.
+
+<PackageManagerTabs command="npx servercn-cli@latest add pr mysql-drizzle" />
+
+[Read more](/docs/nextjs/providers/mysql-drizzle)
+
+<br />
+---
+<br />
+
+#### 25 June, 2026 - Next.js Mongodb(Mongoose) Provider
+
+- Added the <Code>mongodb-mongoose</Code> provider for Next.js.
+
+<PackageManagerTabs command="npx servercn-cli@latest add pr mongodb-mongoose" />
+
+[Read more](/docs/nextjs/providers/mongodb-mongoose)
+
+<br />
+---
+<br />
+
 #### 20 June, 2026 - Express.js Rate Limiter Component
 
 - Added <Code>upstash</Code> and <Code>ioredis</Code> variants for the Rate Limiter component.


### PR DESCRIPTION
add changelog entries for the mysql-drizzle and mongodb-mongoose Next.js database providers, including their install commands and readmore documentation links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new provider announcements to the changelog: Next.js MySQL (Drizzle) and Next.js MongoDB (Mongoose).
  * Each entry includes install instructions and a link to learn more.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->