### PR TITLE
feat(drizzle-providers): add nextjs framework support

### DIFF
--- a/apps/web/public/sr/index.json
+++ b/apps/web/public/sr/index.json
@@ -353,7 +353,8 @@
       "type": "provider",
       "slug": "pg-drizzle",
       "frameworks": [
-        "express"
+        "express",
+        "nextjs"
       ]
     },
     {

--- a/apps/web/public/sr/provider/mysql-drizzle.json
+++ b/apps/web/public/sr/provider/mysql-drizzle.json
@@ -32,11 +32,6 @@
                 },
                 {
                   "type": "file",
-                  "path": "src/db/index.ts",
-                  "content": "//? Export all schemas from schemas directory\r\n\r\nexport * from \"./schemas/user.schema\";\r\n"
-                },
-                {
-                  "type": "file",
                   "path": "src/configs/env.ts",
                   "content": "import dotenv from \"dotenv-flow\";\r\ndotenv.config();\r\nimport { z } from \"zod\";\r\n\r\nexport const envSchema = z.object({\r\n  NODE_ENV: z\r\n    .enum([\"development\", \"test\", \"production\"])\r\n    .default(\"development\"),\r\n\r\n  DATABASE_URL: z.url()\r\n});\r\n\r\nexport type Env = z.infer<typeof envSchema>;\r\n\r\nconst result = envSchema.safeParse(process.env);\r\n\r\nif (!result.success) {\r\n  console.error(\"❌ Invalid environment configuration\");\r\n  console.error(z.prettifyError(result.error));\r\n  process.exit(1);\r\n}\r\n\r\nexport const env: Readonly<Env> = Object.freeze(result.data);\r\n\r\nexport default env;\r\n"
                 },
@@ -44,6 +39,11 @@
                   "type": "file",
                   "path": "src/configs/db.ts",
                   "content": "import { drizzle } from \"drizzle-orm/mysql2\";\r\nimport env from \"./env\";\r\n\r\nconst db = drizzle(env.DATABASE_URL!, {\r\n  logger: env.NODE_ENV === \"development\"\r\n});\r\n\r\nexport default db;\r\n\r\n/**\r\n * ? Usage:\r\n *  await db.insert(usersTable).values(user);\r\n */\r\n"
+                },
+                {
+                  "type": "file",
+                  "path": "src/db/index.ts",
+                  "content": "//? Export all schemas from schemas directory\r\n\r\nexport * from \"./schemas/user.schema\";\r\n"
                 },
                 {
                   "type": "file",
@@ -71,6 +71,11 @@
                 },
                 {
                   "type": "file",
+                  "path": "src/db/schemas/user.schema.ts",
+                  "content": "import { mysqlTable, serial, varchar } from \"drizzle-orm/mysql-core\";\r\n\r\nexport const usersTable = mysqlTable(\"users\", {\r\n  id: serial().primaryKey(),\r\n  name: varchar({ length: 255 }).notNull(),\r\n  email: varchar({ length: 255 }).notNull().unique(),\r\n  password: varchar(\"password\", { length: 255 }).notNull()\r\n});\r\n"
+                },
+                {
+                  "type": "file",
                   "path": "src/shared/configs/env.ts",
                   "content": "import dotenv from \"dotenv-flow\";\r\ndotenv.config();\r\nimport { z } from \"zod\";\r\n\r\nexport const envSchema = z.object({\r\n  NODE_ENV: z\r\n    .enum([\"development\", \"test\", \"production\"])\r\n    .default(\"development\"),\r\n\r\n  DATABASE_URL: z.url()\r\n});\r\n\r\nexport type Env = z.infer<typeof envSchema>;\r\n\r\nconst result = envSchema.safeParse(process.env);\r\n\r\nif (!result.success) {\r\n  console.error(\"❌ Invalid environment configuration\");\r\n  console.error(z.prettifyError(result.error));\r\n  process.exit(1);\r\n}\r\n\r\nexport const env: Readonly<Env> = Object.freeze(result.data);\r\n\r\nexport default env;\r\n"
                 },
@@ -78,11 +83,6 @@
                   "type": "file",
                   "path": "src/shared/configs/db.ts",
                   "content": "import { drizzle } from \"drizzle-orm/mysql2\";\r\nimport env from \"./env\";\r\n\r\nconst db = drizzle(env.DATABASE_URL!, {\r\n  logger: env.NODE_ENV === \"development\"\r\n});\r\n\r\nexport default db;\r\n\r\n/**\r\n * ? Usage:\r\n *  await db.insert(usersTable).values(user);\r\n */"
-                },
-                {
-                  "type": "file",
-                  "path": "src/db/schemas/user.schema.ts",
-                  "content": "import { mysqlTable, serial, varchar } from \"drizzle-orm/mysql-core\";\r\n\r\nexport const usersTable = mysqlTable(\"users\", {\r\n  id: serial().primaryKey(),\r\n  name: varchar({ length: 255 }).notNull(),\r\n  email: varchar({ length: 255 }).notNull().unique(),\r\n  password: varchar(\"password\", { length: 255 }).notNull()\r\n});\r\n"
                 }
               ]
             }

--- a/apps/web/public/sr/provider/pg-drizzle.json
+++ b/apps/web/public/sr/provider/pg-drizzle.json
@@ -72,11 +72,6 @@
                 },
                 {
                   "type": "file",
-                  "path": "src/db/schemas/user.schema.ts",
-                  "content": "import { integer, pgTable, varchar } from \"drizzle-orm/pg-core\";\r\n\r\nexport const usersTable = pgTable(\"users\", {\r\n  id: integer().primaryKey().generatedAlwaysAsIdentity(),\r\n  name: varchar({ length: 255 }).notNull(),\r\n  age: integer().notNull(),\r\n  email: varchar({ length: 255 }).notNull().unique()\r\n});\r\n\r\nexport type User = typeof usersTable.$inferSelect;\r\nexport type NewUser = typeof usersTable.$inferInsert;\r\n"
-                },
-                {
-                  "type": "file",
                   "path": "src/shared/configs/env.ts",
                   "content": "import dotenv from \"dotenv-flow\";\r\ndotenv.config();\r\nimport { z } from \"zod\";\r\n\r\nexport const envSchema = z.object({\r\n  NODE_ENV: z\r\n    .enum([\"development\", \"test\", \"production\"])\r\n    .default(\"development\"),\r\n\r\n  DATABASE_URL: z.url()\r\n});\r\n\r\nexport type Env = z.infer<typeof envSchema>;\r\n\r\nconst result = envSchema.safeParse(process.env);\r\n\r\nif (!result.success) {\r\n  console.error(\"❌ Invalid environment configuration\");\r\n  console.error(z.prettifyError(result.error));\r\n  process.exit(1);\r\n}\r\n\r\nexport const env: Readonly<Env> = Object.freeze(result.data);\r\n\r\nexport default env;\r\n"
                 },
@@ -84,6 +79,58 @@
                   "type": "file",
                   "path": "src/shared/configs/db.ts",
                   "content": "import { drizzle } from \"drizzle-orm/node-postgres\";\r\nimport env from \"./env\";\r\n\r\nconst db = drizzle(env.DATABASE_URL!, {\r\n  logger: env.NODE_ENV === \"development\"\r\n});\r\n\r\nexport default db;\r\n\r\n/**\r\n * ? Usage:\r\n *  await db.insert(usersTable).values(user);\r\n */\r\n"
+                },
+                {
+                  "type": "file",
+                  "path": "src/db/schemas/user.schema.ts",
+                  "content": "import { integer, pgTable, varchar } from \"drizzle-orm/pg-core\";\r\n\r\nexport const usersTable = pgTable(\"users\", {\r\n  id: integer().primaryKey().generatedAlwaysAsIdentity(),\r\n  name: varchar({ length: 255 }).notNull(),\r\n  age: integer().notNull(),\r\n  email: varchar({ length: 255 }).notNull().unique()\r\n});\r\n\r\nexport type User = typeof usersTable.$inferSelect;\r\nexport type NewUser = typeof usersTable.$inferInsert;\r\n"
+                }
+              ]
+            }
+          }
+        },
+        "nextjs": {
+          "dependencies": {
+            "runtime": [
+              "drizzle-orm",
+              "pg"
+            ],
+            "dev": [
+              "drizzle-kit",
+              "@types/pg"
+            ]
+          },
+          "env": [
+            "DATABASE_URL",
+            "NODE_ENV"
+          ],
+          "architectures": {
+            "file-api": {
+              "files": [
+                {
+                  "type": "file",
+                  "path": "drizzle.config.ts",
+                  "content": "import { defineConfig } from \"drizzle-kit\";\r\n\r\nexport default defineConfig({\r\n  out: \"./migrations\",\r\n  schema: \"./src/db/index.ts\",\r\n  dialect: \"postgresql\",\r\n  dbCredentials: {\r\n    url: process.env.DATABASE_URL!\r\n  },\r\n  verbose: true,\r\n  strict: true\r\n});\r\n\r\n/**\r\n *? Add the following scripts to your package.json:\r\n *\r\n * 1. \"db:generate\": \"drizzle-kit generate\" //* Generate migration files\r\n * 2. \"db:migrate\": \"drizzle-kit migrate\"   //* Apply migrations to the database\r\n * 3. \"db:studio\": \"drizzle-kit studio\"     //* Open Drizzle Studio\r\n\r\n * 4. \"db:push\": \"npx drizzle-kit push\"  //* You can directly apply changes to your database using this command.\r\n **/\r\n"
+                },
+                {
+                  "type": "file",
+                  "path": "migrations/.gitkeep",
+                  "content": ""
+                },
+                {
+                  "type": "file",
+                  "path": "src/db/index.ts",
+                  "content": "//? Export all schemas from ./schemas directory\r\nexport * from \"./schemas/user.schema\";\r\n"
+                },
+                {
+                  "type": "file",
+                  "path": "src/db/connection.ts",
+                  "content": "import { drizzle } from \"drizzle-orm/node-postgres\";\r\n\r\nconst db = drizzle(process.env.DATABASE_URL!);\r\n\r\nexport default db;"
+                },
+                {
+                  "type": "file",
+                  "path": "src/db/schemas/user.schema.ts",
+                  "content": "import { integer, pgTable, varchar } from \"drizzle-orm/pg-core\";\r\n\r\nexport const usersTable = pgTable(\"users_table\", {\r\n  id: integer().primaryKey().generatedAlwaysAsIdentity(),\r\n  name: varchar({ length: 255 }).notNull(),\r\n  age: integer().notNull(),\r\n  email: varchar({ length: 255 }).notNull().unique()\r\n});\r\n"
                 }
               ]
             }

--- a/packages/registry/provider/pg-drizzle.json
+++ b/packages/registry/provider/pg-drizzle.json
@@ -14,6 +14,16 @@
             "dev": ["drizzle-kit", "@types/pg"]
           },
           "env": ["DATABASE_URL", "NODE_ENV"]
+        },
+        "nextjs": {
+          "templates": {
+            "file-api": "pg-drizzle/file-api"
+          },
+          "dependencies": {
+            "runtime": ["drizzle-orm", "pg"],
+            "dev": ["drizzle-kit", "@types/pg"]
+          },
+          "env": ["DATABASE_URL", "NODE_ENV"]
         }
       }
     }


### PR DESCRIPTION
- update provider registries to include nextjs support for pg-drizzle
- add nextjs-specific template files and dependency configs
- reorder file templates for mysql-drizzle to match standard structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added **Next.js** support for the `pg-drizzle` provider.
  * Expanded provider configuration to recognize Next.js alongside the existing Express setup.
  * Improved template ordering and registry metadata for database starter options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->