### PR TITLE
feat(pg-drizzle-neon): add initial file api with drizzle and neon pos…

### DIFF
--- a/packages/templates/node/nextjs/package-lock.json
+++ b/packages/templates/node/nextjs/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "drizzle-orm": "^0.45.2",
+        "@neondatabase/serverless": "^1.1.0",
+        "drizzle-orm": "^1.0.0-rc.4",
         "mongoose": "^9.7.2",
         "mysql2": "^3.22.5",
         "pg": "^8.22.0"
@@ -913,6 +914,15 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@neondatabase/serverless": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@neondatabase/serverless/-/serverless-1.1.0.tgz",
+      "integrity": "sha512-r3ZZhRjEcfEdKIZnoB1RusNgvHuaBRqfCzV4Gi+5A9yUX0S4HTws/ASWqt13wL4y4I+0rqsWGdA2w7EQXHi3+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
     "node_modules/@types/node": {
       "version": "26.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
@@ -1000,13 +1010,22 @@
       }
     },
     "node_modules/drizzle-orm": {
-      "version": "0.45.2",
-      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.2.tgz",
-      "integrity": "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==",
+      "version": "1.0.0-rc.4",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-1.0.0-rc.4.tgz",
+      "integrity": "sha512-BT+pf+qoiYHqltoA88Jmf6ilGMXPlpfE0hEJKc2adRtMCAl25Swk/t5gXcWxZNAwdtf3F5gCd2FpeOyP/pT0Hw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=4",
+        "@effect/sql-d1": ">=4.0.0-beta.83 || >=4.0.0",
+        "@effect/sql-libsql": ">=4.0.0-beta.83 || >=4.0.0",
+        "@effect/sql-mysql2": ">=4.0.0-beta.83 || >=4.0.0",
+        "@effect/sql-pg": ">=4.0.0-beta.83 || >=4.0.0",
+        "@effect/sql-pglite": ">=4.0.0-beta.83 || >=4.0.0",
+        "@effect/sql-sqlite-bun": ">=4.0.0-beta.83 || >=4.0.0",
+        "@effect/sql-sqlite-do": ">=4.0.0-beta.83 || >=4.0.0",
+        "@effect/sql-sqlite-node": ">=4.0.0-beta.83 || >=4.0.0",
+        "@effect/sql-sqlite-wasm": ">=4.0.0-beta.83 || >=4.0.0",
         "@electric-sql/pglite": ">=0.2.0",
         "@libsql/client": ">=0.10.0",
         "@libsql/client-wasm": ">=0.10.0",
@@ -1014,31 +1033,68 @@
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
         "@planetscale/database": ">=1.13",
-        "@prisma/client": "*",
+        "@sinclair/typebox": ">=0.34.8",
+        "@sqlitecloud/drivers": ">=1.0.653",
         "@tidbcloud/serverless": "*",
+        "@tursodatabase/database": ">=0.6.0-pre.28 || >=0.6.0",
+        "@tursodatabase/database-common": ">=0.6.0-pre.28 || >=0.6.0",
+        "@tursodatabase/database-wasm": ">=0.6.0-pre.28 || >=0.6.0",
+        "@tursodatabase/serverless": ">=1.1.3",
+        "@tursodatabase/sync": ">=0.6.0-pre.28 || >=0.6.0",
         "@types/better-sqlite3": "*",
+        "@types/mssql": "^9.1.4",
         "@types/pg": "*",
         "@types/sql.js": "*",
         "@upstash/redis": ">=1.34.7",
         "@vercel/postgres": ">=0.8.0",
         "@xata.io/client": "*",
-        "better-sqlite3": ">=7",
+        "arktype": ">=2.0.0",
+        "better-sqlite3": ">=9.3.0",
         "bun-types": "*",
+        "effect": ">=4.0.0-beta.83 || >=4.0.0",
         "expo-sqlite": ">=14.0.0",
-        "gel": ">=2",
-        "knex": "*",
-        "kysely": "*",
+        "mssql": "^11.0.1",
         "mysql2": ">=2",
         "pg": ">=8",
         "postgres": ">=3",
         "sql.js": ">=1",
-        "sqlite3": ">=5"
+        "sqlite3": ">=5",
+        "typebox": ">=1.0.0",
+        "valibot": ">=1.0.0-beta.7",
+        "zod": "^3.25.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/client-rds-data": {
           "optional": true
         },
         "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@effect/sql-d1": {
+          "optional": true
+        },
+        "@effect/sql-libsql": {
+          "optional": true
+        },
+        "@effect/sql-mysql2": {
+          "optional": true
+        },
+        "@effect/sql-pg": {
+          "optional": true
+        },
+        "@effect/sql-pglite": {
+          "optional": true
+        },
+        "@effect/sql-sqlite-bun": {
+          "optional": true
+        },
+        "@effect/sql-sqlite-do": {
+          "optional": true
+        },
+        "@effect/sql-sqlite-node": {
+          "optional": true
+        },
+        "@effect/sql-sqlite-wasm": {
           "optional": true
         },
         "@electric-sql/pglite": {
@@ -1062,13 +1118,34 @@
         "@planetscale/database": {
           "optional": true
         },
-        "@prisma/client": {
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@sqlitecloud/drivers": {
           "optional": true
         },
         "@tidbcloud/serverless": {
           "optional": true
         },
+        "@tursodatabase/database": {
+          "optional": true
+        },
+        "@tursodatabase/database-common": {
+          "optional": true
+        },
+        "@tursodatabase/database-wasm": {
+          "optional": true
+        },
+        "@tursodatabase/serverless": {
+          "optional": true
+        },
+        "@tursodatabase/sync": {
+          "optional": true
+        },
         "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/mssql": {
           "optional": true
         },
         "@types/pg": {
@@ -1086,22 +1163,22 @@
         "@xata.io/client": {
           "optional": true
         },
+        "arktype": {
+          "optional": true
+        },
         "better-sqlite3": {
           "optional": true
         },
         "bun-types": {
           "optional": true
         },
+        "effect": {
+          "optional": true
+        },
         "expo-sqlite": {
           "optional": true
         },
-        "gel": {
-          "optional": true
-        },
-        "knex": {
-          "optional": true
-        },
-        "kysely": {
+        "mssql": {
           "optional": true
         },
         "mysql2": {
@@ -1113,13 +1190,19 @@
         "postgres": {
           "optional": true
         },
-        "prisma": {
-          "optional": true
-        },
         "sql.js": {
           "optional": true
         },
         "sqlite3": {
+          "optional": true
+        },
+        "typebox": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "zod": {
           "optional": true
         }
       }

--- a/packages/templates/node/nextjs/package.json
+++ b/packages/templates/node/nextjs/package.json
@@ -6,7 +6,8 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
-    "drizzle-orm": "^0.45.2",
+    "@neondatabase/serverless": "^1.1.0",
+    "drizzle-orm": "^1.0.0-rc.4",
     "mongoose": "^9.7.2",
     "mysql2": "^3.22.5",
     "pg": "^8.22.0"

--- a/packages/templates/node/nextjs/provider/pg-drizzle-neon/file-api/drizzle.config.ts
+++ b/packages/templates/node/nextjs/provider/pg-drizzle-neon/file-api/drizzle.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  out: "./migrations",
+  schema: "./src/db/index.ts",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!
+  },
+  verbose: true,
+  strict: true
+});
+
+/**
+ *? Add the following scripts to your package.json:
+ *
+ * 1. "db:generate": "drizzle-kit generate" //* Generate migration files
+ * 2. "db:migrate": "drizzle-kit migrate"   //* Apply migrations to the database
+ * 3. "db:studio": "drizzle-kit studio"     //* Open Drizzle Studio
+
+ * 4. "db:push": "npx drizzle-kit push"  //* You can directly apply changes to your database using this command.
+ **/

--- a/packages/templates/node/nextjs/provider/pg-drizzle-neon/file-api/src/db/connection.ts
+++ b/packages/templates/node/nextjs/provider/pg-drizzle-neon/file-api/src/db/connection.ts
@@ -1,0 +1,7 @@
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+
+const sql = neon(process.env.DATABASE_URL!);
+const db = drizzle({ client: sql });
+
+export default db;

--- a/packages/templates/node/nextjs/provider/pg-drizzle-neon/file-api/src/db/index.ts
+++ b/packages/templates/node/nextjs/provider/pg-drizzle-neon/file-api/src/db/index.ts
@@ -1,0 +1,2 @@
+//? Export all schemas from ./schemas directory
+export * from "./schemas/user.schema";

--- a/packages/templates/node/nextjs/provider/pg-drizzle-neon/file-api/src/db/schemas/user.schema.ts
+++ b/packages/templates/node/nextjs/provider/pg-drizzle-neon/file-api/src/db/schemas/user.schema.ts
@@ -1,0 +1,8 @@
+import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
+
+export const usersTable = pgTable("users_table", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  name: varchar({ length: 255 }).notNull(),
+  age: integer().notNull(),
+  email: varchar({ length: 255 }).notNull().unique()
+});


### PR DESCRIPTION
…tgres

add database connection logic, base user schema, drizzle kit configuration, update project dependencies, set up migrations directory, and include usage notes in the drizzle config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a PostgreSQL-backed database setup for the Next.js template.
  * Included a new user data schema with ID, name, age, and email fields.

* **Chores**
  * Updated database-related dependencies for the template.
  * Added configuration needed for generating and managing database migrations.
  * Added a ready-to-use database connection for the template app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->