### PR TITLE
feat: add nextjs support for pg-drizzle-neon provider

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -178,7 +178,7 @@
 - [Mongodb(Mongoose)](https://www.servercn.xyz/docs/nextjs/providers/mongodb-mongoose): sets up MongoDB connectivity with Mongoose for nextjs projects, including database connection.
 - [Mysql(Drizzle) ](https://www.servercn.xyz/docs/nextjs/providers/mysql-drizzle): sets up MySQL connectivity with Drizzle ORM for nextjs projects.
 - [PostgreSQL(Drizzle) ](https://www.servercn.xyz/docs/nextjs/providers/pg-drizzle): sets up PostgreSQL connectivity with Drizzle ORM for nextjs projects.
-
+- [PostgreSQL(Drizzle & Neon) ](https://www.servercn.xyz/docs/nextjs/providers/pg-drizzle-neon):  sets up PostgreSQL + Neon connectivity with Drizzle ORM for nextjs projects.
 
 
 ## Schemas

--- a/apps/web/src/components/command/search-command.tsx
+++ b/apps/web/src/components/command/search-command.tsx
@@ -26,13 +26,7 @@ import { BASE_GITHUB_URL, DISCORD_URL, GITHUB_URL } from "@/lib/constants";
 import { contributingGuides } from "@/lib/contributing";
 import { useFramework } from "@/store/use-framework";
 
-export function SearchCommand({
-  className,
-  size
-}: {
-  className?: string;
-  size?: "sm" | "lg";
-}) {
+export function SearchCommand({ className }: { className?: string }) {
   const [open, setOpen] = React.useState(false);
   const { framework } = useFramework();
 

--- a/apps/web/src/content/docs/express/providers/pg-drizzle-neon.mdx
+++ b/apps/web/src/content/docs/express/providers/pg-drizzle-neon.mdx
@@ -1,10 +1,10 @@
 ---
-title: PostgreSQL + Neon (Drizzle) | Provider
+title: PostgreSQL (Drizzle & Neon) | Provider
 description: PostgreSQL + Neon provider with Drizzle ORM for Express applications.
 command: npx servercn-cli@latest add pr pg-drizzle-neon
 ---
 
-# PostgreSQL(Drizzle) Provider
+# PostgreSQL(Drizzle & Neon) Provider
 
 This provider sets up PostgreSQL + Neon connectivity with Drizzle ORM for Express projects, including environment validation, a database client.
 

--- a/apps/web/src/content/docs/nextjs/providers/pg-drizzle-neon.mdx
+++ b/apps/web/src/content/docs/nextjs/providers/pg-drizzle-neon.mdx
@@ -1,0 +1,177 @@
+---
+title:  PostgreSQL(Drizzle & Neon) | Provider | Next.js
+description:  PostgreSQL provider with drizzle ORM & Neon DB for nextjs applications.
+command: npx servercn-cli@latest add pr pg-drizzle-neon
+---
+
+# PostgreSQL(Drizzle & Neon) Provider
+
+This provider sets up PostgreSQL + Neon connectivity with Drizzle ORM for nextjs projects.
+
+[Official Docs](https://orm.drizzle.team/docs/get-started/neon-new)
+
+---
+
+## Installation Guide
+
+<Tabs defaultValue="command">
+<TabsList>
+<TabsTrigger value="command">
+Command
+</TabsTrigger>
+<TabsTrigger value="manual">
+Manual
+</TabsTrigger>
+</TabsList>
+<TabsContent value="command">
+<Steps>
+<Step>Run the following command:</Step>
+<PackageManagerTabs command="npx servercn-cli@latest add pr pg-drizzle-neon" />
+
+<Step> Add the following scripts to your package.json:</Step>
+```json title="package.json"
+{
+  "scripts": {
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio",
+    "db:push": "npx drizzle-kit push"
+  },
+}
+```
+</Steps>
+</TabsContent>    
+<TabsContent value="manual">
+<Steps>
+<Step>Install Dependencies:</Step>
+<PackageManagerTabs command="npm install drizzle-orm@rc @neondatabase/serverless" />
+<PackageManagerTabs command="npm install -D drizzle-kit@rc" />
+
+<Step> Add the following scripts to your package.json:</Step>
+```json title="package.json"
+{
+  "scripts": {
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:studio": "drizzle-kit studio",
+    "db:push": "npx drizzle-kit push"
+  },
+}
+```
+
+<Step>Add Env Variables</Step>
+```dotenv title=".env"
+DATABASE_URL='database_url'
+NODE_ENV='node_env'
+```
+
+<Step>Add Drizzle Configuration</Step>
+```ts title="drizzle.config.ts"
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  out: "./migrations",
+  schema: "./src/db/index.ts",
+  dialect: "postgresql",
+  dbCredentials: {
+    url: process.env.DATABASE_URL!
+  },
+  verbose: true,
+  strict: true
+});
+```
+
+<Step>Add DB Connection</Step>
+```ts title="src/db/connection.ts"
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+
+const sql = neon(process.env.DATABASE_URL!);
+const db = drizzle({
+  client: sql,
+  logger: process.env.NODE_ENV === "development"
+});
+
+export default db;
+```
+
+<Step>Add User Schema</Step>
+```ts title="src/db/schemas/user.schema.ts"
+import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
+
+export const usersTable = pgTable("users_table", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  name: varchar({ length: 255 }).notNull(),
+  age: integer().notNull(),
+  email: varchar({ length: 255 }).notNull().unique()
+});
+```
+
+<Step>Export Schemas</Step>
+```ts title="src/db/index.ts"
+//? Export all schemas from ./schemas directory
+export * from "./schemas/user.schema";
+```
+
+</Steps> 
+</TabsContent>
+</Tabs>
+
+
+---
+
+## Usage Example
+```ts
+import db from "@/db/connection";
+```
+
+```ts title="src/app/api/route.ts"
+import { usersTable } from "@/db";
+import db from "@/db/connection";
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+
+export const GET = async () => {
+  try {
+    const user: typeof usersTable.$inferInsert = {
+      name: "John",
+      age: 30,
+      email: "john123@example.com"
+    };
+
+    await db.insert(usersTable).values(user);
+    console.log("New user created!");
+
+    const users = await db.select().from(usersTable);
+    console.log("Getting all users from the database: ", users);
+    await db
+      .update(usersTable)
+      .set({
+        age: 31
+      })
+      .where(eq(usersTable.email, user.email));
+    console.log("User info updated!");
+
+    await db.delete(usersTable).where(eq(usersTable.email, user.email));
+    console.log("User deleted!");
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: users
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Delete error:", error);
+
+    return NextResponse.json(
+      {
+        success: false,
+        message: "Internal server error"
+      },
+      { status: 500 }
+    );
+  }
+};
+```

--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -741,10 +741,7 @@
       "frameworks": ["express"],
       "title": "MySQL (Prisma)",
       "description": "MySQL provider with Prisma ORM for Express applications.",
-      "docs": "/docs/providers/mysql-prisma",
-      "meta": {
-        "new": true
-      }
+      "docs": "/docs/providers/mysql-prisma"
     },
     {
       "slug": "mysql-drizzle",
@@ -774,9 +771,9 @@
       "slug": "pg-drizzle-neon",
       "type": "provider",
       "status": "stable",
-      "frameworks": ["express"],
+      "frameworks": ["express", "nextjs"],
       "title": "PostgreSQL Neon (Drizzle)",
-      "description": "PostgreSQL + Neon provider with Drizzle ORM for Express applications.",
+      "description": "PostgreSQL + Neon provider with Drizzle ORM for expressjs & nextjs applications.",
       "docs": "/docs/providers/pg-drizzle-neon",
       "meta": {
         "new": true

--- a/apps/web/src/lib/source.ts
+++ b/apps/web/src/lib/source.ts
@@ -1,9 +1,4 @@
-import {
-  Framework,
-  FrameworkType,
-  IRegistryItems,
-  ItemType
-} from "@/@types/registry";
+import { FrameworkType, IRegistryItems, ItemType } from "@/@types/registry";
 import registry from "@/data/registry.json";
 
 export const RESTRICTED_FOLDER_STRUCTURE_PAGES = [


### PR DESCRIPTION
- add dedicated nextjs documentation page for the provider
- update registry.json to include nextjs as a supported framework
- update llms.txt to link the new nextjs provider docs
- clean up unused imports in source.ts
- remove unused size prop from SearchCommand component
- align doc titles for pg-drizzle-neon across express and nextjs docs