### PR TITLE
feat: add nextjs support for mongodb-prisma

### DIFF
--- a/apps/web/src/content/docs/guides/installation.mdx
+++ b/apps/web/src/content/docs/guides/installation.mdx
@@ -99,11 +99,6 @@ The Mongoose Starter is a database foundation provided by servercn for projects 
 - Default: <Code children="." /> (current directory)
 - The root directory where your project lives
 
-**Source Directory**
-
-- Default: <Code children="src" />
-- Where your source code will be located
-
 **Architecture**
 
 - **MVC**: Traditional Model-View-Controller structure
@@ -118,6 +113,8 @@ The Mongoose Starter is a database foundation provided by servercn for projects 
 **Backend Framework**
 
 - **Express**: Currently supported framework
+- **Nextjs**: Nextjs based architecture
+
 
 **Database**
 

--- a/apps/web/src/content/docs/nextjs/providers/mongodb-prisma.mdx
+++ b/apps/web/src/content/docs/nextjs/providers/mongodb-prisma.mdx
@@ -1,0 +1,180 @@
+---
+title:  MongoDB (Prisma) | Provider | Next.js
+description:  MongoDB provider with Prisma ORM for nextjs applications.
+command: npx servercn-cli@latest add pr mongodb-prisma
+---
+
+# MongoDB(Prisma) Provider
+
+This provider sets up MongoDB connectivity with Prisma ORM for nextjs projects.
+
+[Official Docs](https://www.prisma.io/docs/prisma-orm/quickstart/mongodb)
+
+---
+
+## Installation Guide
+
+<Tabs defaultValue="command">
+<TabsList>
+<TabsTrigger value="command">
+Command
+</TabsTrigger>
+<TabsTrigger value="manual">
+Manual
+</TabsTrigger>
+</TabsList>
+<TabsContent value="command">
+<Steps>
+<Step>Run the following command:</Step>
+<PackageManagerTabs command="npx servercn-cli@latest add pr mongodb-prisma" />
+
+<Step> Add the following scripts to your package.json:</Step>
+```json title="package.json"
+{
+  "scripts": {
+    "db:generate": "prisma generate",
+    "db:push": "prisma push",
+    "db:studio": "prisma studio"
+  },
+}
+```
+</Steps>
+</TabsContent>    
+<TabsContent value="manual">
+<Steps>
+<Step>Follow the official docs:</Step>
+
+[Official Docs](https://www.prisma.io/docs/prisma-orm/quickstart/mongodb)
+
+<Step>Install Dependencies:</Step>
+<PackageManagerTabs command="npm install @prisma/client@6" />
+<PackageManagerTabs command="npm install -D prisma@6" />
+
+<Step> Add the following scripts to your package.json:</Step>
+```json title="package.json"
+{
+  "scripts": {
+    "db:generate": "prisma generate",
+    "db:push": "prisma push",
+    "db:studio": "prisma studio"
+  },
+}
+```
+
+<Step>Add Env Variables</Step>
+```dotenv title=".env"
+DATABASE_URL='database_url'
+NODE_ENV='node_env'
+```
+
+<Step>Add Prisma Configuration</Step>
+```ts title="prisma.config.ts"
+import { defineConfig, env } from "prisma/config";
+import "dotenv/config"; 
+
+export default defineConfig({
+  schema: "prisma/schema.prisma",
+  migrations: {
+    path: "prisma/migrations",
+  },
+  engine: "classic",
+  datasource: {
+    url: process.env.DATABASE_URL || env("DATABASE_URL"),
+  },
+});
+```
+
+<Step>Add DB Connection</Step>
+```ts title="src/lib/prisma.ts"
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient({
+  log:
+    process.env.NODE_ENV === "development"
+      ? ["query", "info", "warn", "error"]
+      : ["error"]
+});
+
+export default prisma;
+```
+
+<Step>Add Prisma Schema</Step>
+```ts title="prisma/schema.prisma"
+// This is your Prisma schema file,
+// learn more about it in the docs: https://pris.ly/d/prisma-schema
+
+// Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
+// Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model User { 
+  id    String  @id @default(auto()) @map("_id") @db.ObjectId
+  email String  @unique
+  name  String?
+  age   Int?
+  password String
+}
+```
+
+</Steps>    
+</TabsContent>    
+</Tabs>
+
+
+---
+
+## Usage Example
+```ts
+import prisma from "@/lib/prisma";
+```
+
+```ts title="src/app/api/route.ts"
+import prisma from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+export const GET = async () => {
+  const user = {
+    email: "test@test.com",
+    name: "Test User",
+    password: "password123"
+  };
+
+  const createdUser = await prisma.user.create({
+    data: user
+  });
+  console.log("Created user:", JSON.stringify(createdUser, null, 2));
+
+  const allUsers = await prisma.user.findMany();
+  console.log("All users:", JSON.stringify(allUsers, null, 2));
+
+  const updatedUser = await prisma.user.update({
+    where: {
+      email: "test@test.com"
+    },
+    data: {
+      name: "Updated Test User"
+    }
+  });
+  console.log("Updated user:", JSON.stringify(updatedUser, null, 2));
+
+  const deletedUser = await prisma.user.delete({
+    where: {
+      email: "test@test.com"
+    }
+  });
+  console.log("Deleted user:", JSON.stringify(deletedUser, null, 2));
+
+  return NextResponse.json({
+    message: "Successfully executed",
+    createdUser,
+  });
+};
+```

--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -725,9 +725,9 @@
       "slug": "mongodb-prisma",
       "type": "provider",
       "status": "stable",
-      "frameworks": ["express"],
+      "frameworks": ["express", "nextjs"],
       "title": "MongoDB (Prisma)",
-      "description": "MongoDB provider with Prisma ORM for Express applications.",
+      "description": "MongoDB provider with Prisma ORM for expressjs & nextjs applications.",
       "docs": "/docs/providers/mongodb-prisma",
       "meta": {
         "new": true


### PR DESCRIPTION
Update the provider registry entry to include nextjs in the frameworks list and adjust the description to reflect multi-framework support. Create a dedicated Next.js-specific documentation page for the provider, update the installation guide to add Nextjs as a supported backend framework, and remove the outdated Source Directory section from the installation docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new documentation page for the MongoDB (Prisma) provider for Next.js, including setup steps and a usage example.
  * Expanded the supported backend framework options to include Next.js.
* **Documentation**
  * Updated the installation guide to reflect the revised configuration options.
  * Updated provider details to show support for both Express and Next.js applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->