### PR TITLE
docs: add mongodb-prisma provider, update changelog

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -178,7 +178,8 @@
 - [Mongodb(Mongoose)](https://www.servercn.xyz/docs/nextjs/providers/mongodb-mongoose): sets up MongoDB connectivity with Mongoose for nextjs projects, including database connection.
 - [Mysql(Drizzle) ](https://www.servercn.xyz/docs/nextjs/providers/mysql-drizzle): sets up MySQL connectivity with Drizzle ORM for nextjs projects.
 - [PostgreSQL(Drizzle) ](https://www.servercn.xyz/docs/nextjs/providers/pg-drizzle): sets up PostgreSQL connectivity with Drizzle ORM for nextjs projects.
-- [PostgreSQL(Drizzle & Neon) ](https://www.servercn.xyz/docs/nextjs/providers/pg-drizzle-neon):  sets up PostgreSQL + Neon connectivity with Drizzle ORM for nextjs projects.
+- [PostgreSQL(Drizzle & Neon) ](https://www.servercn.xyz/docs/nextjs/providers/pg-drizzle-neon): sets up PostgreSQL + Neon connectivity with Drizzle ORM for nextjs projects.
+- [MongoDB Prisma](https://www.servercn.xyz/docs/nextjs/providers/mongodb-prisma): sets up MongoDB connectivity with Prisma ORM for nextjs projects.
 
 
 ## Schemas

--- a/apps/web/src/content/docs/changelog/index.mdx
+++ b/apps/web/src/content/docs/changelog/index.mdx
@@ -7,6 +7,20 @@ description: Latest updates and announcements.
 
 Latest updates and announcements.
 
+## July 2026
+
+#### 02 July, 2026 - Next.js Mongodb(Prisma) Provider
+
+- Added the <Code>mongodb-prisma</Code> provider for Next.js.
+
+<PackageManagerTabs command="npx servercn-cli@latest add pr mongodb-prisma" />
+
+[Read more](/docs/nextjs/providers/mongodb-prisma)
+
+<br />
+---
+<br />
+
 ## June 2026
 
 #### 29 June, 2026 - Next.js PostgreSQL(Drizzle & Neon) Provider


### PR DESCRIPTION
Add the new Next.js MongoDB Prisma provider entry to the providers list in llms.txt, add the July 2, 2026 changelog entry for the provider, and fix a minor whitespace formatting issue in the existing PostgreSQL(Drizzle & Neon) line.