### PR TITLE
chore(cli): bump to v2.0.10 and update docs and package metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18634,7 +18634,7 @@
     },
     "packages/cli": {
       "name": "servercn-cli",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
         "cli-table3": "^0.6.5",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,8 @@
 # Servercn
 
-Servercn is a component registry for building Node.js backends by composition.
+Servercn is a component registry for building node.js backends.
 
-> The shadcn/ui philosophy for Node.js backends
+> The shadcn/ui philosophy for node.js backends
 
 Visit [Servercn](https://servercn.vercel.app) for more information.
 

--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "servercn-cli",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "servercn-cli",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
         "cli-table3": "^0.6.5",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "servercn-cli",
-  "version": "2.0.9",
-  "description": "Backend components CLI for Node.js & Typescript",
+  "version": "2.0.10",
+  "description": "Backend component registry for node.js & typescript",
   "main": "dist/cli.js",
   "readme": "README.md",
   "bin": {
@@ -29,7 +29,7 @@
   "author": {
     "name": "Akkal Dhami",
     "github": "https://github.com/AkkalDhami",
-    "url": "https://x.com/AavashDhami2127"
+    "url": "https://x.com/_akkal_dhami"
   },
   "license": "MIT",
   "files": [


### PR DESCRIPTION
bump package version from 2.0.9 to 2.0.10
revise README to fix node.js capitalization and adjust wording update package description to match the component registry framing correct the author's social media URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the CLI README wording for more consistent platform naming.
* **Chores**
  * Bumped the CLI package version and refreshed its package metadata, including the short description and author link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->