### PR TITLE
feat(auth): add hybrid authentication feature with MySQL and Drizzle ORM

### DIFF
--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/src/server.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/src/server.ts
@@ -13,11 +13,17 @@ connectDB().then(() => {
     .then(() => {
       logger.info("Redis Connection Success");
       const server = app.listen(port, () => {
-        logger.info(`[server]: Server is running at http://localhost:${port}`);
-        logger.info(`[server]: Environment: ${env.NODE_ENV}`);
+        logger.info("Hybrid Auth API started successfully");
+        logger.info(`URL          : http://localhost:${port}`);
+        logger.info(`Environment  : ${env.NODE_ENV}`);
         logger.info(
-          `[server]: Swagger docs are available at http://localhost:${port}/api/docs`
+          `Version      : ${process.env.npm_package_version ?? "unknown"}`
         );
+        logger.info(`Started At   : ${new Date().toISOString()}`);
+
+        if (env.NODE_ENV !== "production") {
+          logger.info(`API Docs     : http://localhost:${port}/api/docs`);
+        }
       });
 
       configureGracefulShutdown(server);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/src/server.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/src/server.ts
@@ -13,11 +13,17 @@ connectDB().then(() => {
     .then(() => {
       logger.info("Redis Connection Success");
       const server = app.listen(port, () => {
-        logger.info(`[server]: Server is running at http://localhost:${port}`);
-        logger.info(`[server]: Environment: ${env.NODE_ENV}`);
+        logger.info("Hybrid Auth API started successfully");
+        logger.info(`URL          : http://localhost:${port}`);
+        logger.info(`Environment  : ${env.NODE_ENV}`);
         logger.info(
-          `[server]: Swagger docs are available at http://localhost:${port}/api/docs`
+          `Version      : ${process.env.npm_package_version ?? "unknown"}`
         );
+        logger.info(`Started At   : ${new Date().toISOString()}`);
+
+        if (env.NODE_ENV !== "production") {
+          logger.info(`API Docs     : http://localhost:${port}/api/docs`);
+        }
       });
 
       configureGracefulShutdown(server);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/.gitignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/.husky/pre-commit
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/.prettierignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/.prettierrc
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/README.md
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/README.md
@@ -1,0 +1,49 @@
+# Hybrid Auth MYSQL Feature
+
+Minimal Node.js + Express + TypeScript Feature starter using MYSQL, Drizzle ORM, and hybrid authentication (local and OAuth via Passport or similar).
+
+## Features
+
+- Express + TypeScript Feature structure
+- MYSQL + Drizzle integration
+- Hybrid auth: local credentials and OAuth providers (e.g., Google, GitHub)
+- Session-based authentication compatible with production
+- Environment-driven configuration with `.env`
+- Dev and production scripts
+
+## What This Provides
+
+- A clean starting point for credential and OAuth login
+- Prewired Express app with routing and session middleware
+- MYSQL connection wiring ready for your schema and data models
+- TypeScript configuration and scripts for iterative dev and production builds
+- Example environment keys you can enable as needed
+
+## Quick Start
+
+1. Install dependencies:
+   - `npm install`
+2. Configure environment:
+   - Create `.env` (copy from `.env.example` if present).
+   - Set variables shown below.
+3. Run in development:
+   - `npm run dev`
+4. Build and run in production:
+   - `npm run build`
+   - `npm start`
+
+## Requirements
+
+- Node.js 18+
+- MYSQL
+
+## Scripts
+
+- `npm run dev` — start development server
+- `npm run build` — compile TypeScript
+- `npm start` — start compiled app
+
+## Notes
+
+- Never commit `.env` or secrets.
+- Run your Drizzle migrations before starting the app.

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/drizzle.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/drizzle.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "drizzle-kit";
+import { env } from "./src/shared/configs/env";
+
+export default defineConfig({
+  out: "./migrations",
+  schema: "./src/db/index.ts",
+  dialect: "mysql",
+  dbCredentials: {
+    url: env.DATABASE_URL
+  },
+  verbose: true,
+  strict: true
+});

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/package.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "servercn-hybrid-auth",
+  "version": "1.0.0",
+  "main": "dist/server.js",
+  "type": "module",
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development npx tsx watch --clearScreen=false src/server.ts",
+    "build": "rm -rf dist && tsc && tsc-alias",
+    "start": "cross-env NODE_ENV=production node dist/server.js",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio",
+    "typecheck": "tsc --noEmit",
+    "docs": "npx tsx swagger.config.ts",
+    "prepare": "husky",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format:check": "npx prettier . --check",
+    "format:fix": "npx prettier . --write"
+  },
+  "lint-staged": {
+    "src/**/*.ts": [
+      "eslint --fix",
+      "prettier --write",
+      "tsc --noEmit"
+    ]
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/app.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/app.ts
@@ -1,0 +1,42 @@
+import express, { Express, Request, Response } from "express";
+import cookieParser from "cookie-parser";
+import morgan from "morgan";
+import { notFoundHandler } from "./shared/middlewares/not-found-handler";
+import { errorHandler } from "./shared/middlewares/error-handler";
+import env from "./shared/configs/env";
+import { configureSecurityHeaders } from "./shared/middlewares/security-header";
+
+import Routes from "./routes/index";
+
+import "./shared/configs/passport";
+import sourceMapSupport from "source-map-support";
+import { setupSwagger } from "./shared/configs/swagger";
+sourceMapSupport.install();
+
+const app: Express = express();
+
+//? Apply security headers before other middlewares and routes
+configureSecurityHeaders(app);
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(cookieParser());
+app.use(morgan(env.NODE_ENV === "development" ? "dev" : "combined"));
+
+//? Swagger Setup
+setupSwagger(app);
+
+//? Routes
+app.get("/", (req: Request, res: Response) => {
+  res.redirect("/api/v1/health");
+});
+
+app.use("/api", Routes);
+
+//? Not-found-handler (should be after routes)
+app.use(notFoundHandler);
+
+//? Global error handler (should be last)
+app.use(errorHandler);
+
+export default app;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/db/index.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/db/index.ts
@@ -1,0 +1,3 @@
+//? Export all schemas from schemas directory
+
+export * from "./schemas/user.schema";

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/db/schemas/schema.helper.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/db/schemas/schema.helper.ts
@@ -1,0 +1,9 @@
+import { timestamp } from "drizzle-orm/mysql-core";
+
+export const timestamps = {
+  createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date" })
+    .defaultNow()
+    .onUpdateNow()
+    .notNull()
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/db/schemas/user.schema.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/db/schemas/user.schema.ts
@@ -1,0 +1,56 @@
+import {
+  mysqlTable,
+  serial,
+  varchar,
+  boolean,
+  timestamp,
+  int,
+  json,
+  uniqueIndex,
+  index,
+  mysqlEnum
+} from "drizzle-orm/mysql-core";
+import { timestamps } from "./schema.helper";
+
+export interface IAvatar {
+  public_id?: string;
+  url: string;
+  size?: number;
+}
+
+export const users = mysqlTable(
+  "users",
+  {
+    id: serial("id").primaryKey(),
+    name: varchar("name", { length: 100 }).notNull(),
+    email: varchar("email", { length: 255 }).notNull().unique(),
+    password: varchar("password", { length: 255 }),
+    role: mysqlEnum("role", ["user", "admin"]).default("user").notNull(),
+
+    provider: mysqlEnum("provider", ["local", "google", "github", "facebook"])
+      .default("local")
+      .notNull(),
+    providerId: varchar("provider_id", { length: 255 }),
+
+    avatar: json("avatar").$type<IAvatar>(),
+
+    isEmailVerified: boolean("is_email_verified").default(false).notNull(),
+    lastLoginAt: timestamp("last_login_at"),
+    failedLoginAttempts: int("failed_login_attempts").default(0).notNull(),
+    lockUntil: timestamp("lock_until"),
+
+    isDeleted: boolean("is_deleted").default(false).notNull(),
+    deletedAt: timestamp("deleted_at"),
+    reActivateAvailableAt: timestamp("re_activate_available_at"),
+
+    ...timestamps
+  },
+  table => [
+    uniqueIndex("email_idx").on(table.email),
+    index("role_idx").on(table.role),
+    index("is_deleted_idx").on(table.isDeleted)
+  ]
+);
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/docs/swagger.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/docs/swagger.json
@@ -1,0 +1,275 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Hybrid Auth API",
+    "description": "Hybrid Auth API",
+    "version": "1.0.0"
+  },
+  "host": "localhost:9000/api",
+  "basePath": "/",
+  "schemes": ["http"],
+  "paths": {
+    "/v1/health/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/verify-otp": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/signup": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                },
+                "role": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/signin": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/profile": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      },
+      "patch": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/refresh-token": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/logout": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/forgot-password": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/reset-password": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/change-password": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/delete-account": {
+      "delete": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/reactivate-account": {
+      "put": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/github": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/github/callback": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/google": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/google/callback": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/github": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/github/callback": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/google": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/google/callback": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.constants.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.constants.ts
@@ -1,0 +1,34 @@
+export const OTP_MAX_ATTEMPTS = 5;
+
+export const OTP_TYPES = [
+  "signin",
+  "email-verification",
+  "password-reset",
+  "password-change"
+] as const;
+
+export const NEXT_OTP_DELAY = 1 * 60 * 1000; // 1 minute
+
+export const LOGIN_MAX_ATTEMPTS = 5 as const;
+
+export const OTP_CODE_LENGTH = 6 as const;
+
+export const OTP_COOL_DOWN = 60;
+
+export const OTP_EXPIRES_IN = 5 * 60 * 1000; // 5 minutes
+
+export const OTP_SPAM_LOCK_TIME = 3600; // 1 hour
+
+export const LOCK_TIME_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export const ACCESS_TOKEN_EXPIRY = 15 * 60 * 1000; // 15 minutes
+
+export const REFRESH_TOKEN_EXPIRY = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export const SESSION_EXPIRY = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export const RESET_PASSWORD_TOKEN_EXPIRY = 5 * 60 * 1000; // 5 minutes
+
+export const REACTIVATION_AVAILABLE_AT = 24 * 60 * 60 * 1000; // 24 hours
+
+export const DELETE_ACCOUNT_TOKEN_EXPIRY = 5 * 60 * 1000; // 5 minutes

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.controller.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.controller.ts
@@ -1,0 +1,463 @@
+import { NextFunction, Request, Response } from "express";
+import { ApiResponse } from "@/shared/utils/api-response";
+import { AsyncHandler } from "@/shared/utils/async-handler";
+
+import { ApiError } from "@/shared/utils/api-error";
+import { authService, AuthService } from "./auth.service";
+import {
+  clearAuthCookies,
+  setAuthCookies
+} from "@/shared/helpers/cookie.helper";
+import { AvatarData } from "./auth.interfaces";
+import {
+  deleteFileFromCloudinary,
+  uploadToCloudinary
+} from "../upload/upload.service";
+import { DeleteAccountType, VerifyOtpType } from "./auth.validation";
+import db from "@/shared/configs/db";
+import { users } from "@/db/schemas/user.schema";
+import { eq } from "drizzle-orm";
+import { UserRequest } from "@/types/global";
+
+//? SIGNUP USER
+export const signupUser = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { name, email, password, role } = req.body;
+    if (!name || !email || !password) {
+      return next(ApiError.badRequest("Name, email and password are required"));
+    }
+
+    await authService.registerUser({
+      name,
+      email,
+      password,
+      role
+    });
+
+    return ApiResponse.created(
+      res,
+      "User registered successfully. Please check your email for verification."
+    );
+  }
+);
+
+//? VERIFY USER
+export const verifyUser = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email, otpCode }: VerifyOtpType = req.body;
+
+    if (!email || !otpCode) {
+      return next(ApiError.badRequest("Email and code are required"));
+    }
+
+    await authService.verifyUser({ email, otpCode });
+
+    return ApiResponse.ok(res, "User verified successfully");
+  }
+);
+
+//? SIGNIN USER
+export const signinUser = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return next(ApiError.badRequest("Email and password are required"));
+    }
+
+    const ip = req.ip || "Unknown";
+    const userAgent = req.headers["user-agent"] || "Unknown";
+
+    await authService.signinUser(
+      { email, password, ip, userAgent },
+      {
+        setAuthCookie: (
+          accessToken: string,
+          refreshToken: string,
+          sessionId: string
+        ) => {
+          setAuthCookies(res, accessToken, refreshToken, sessionId);
+        }
+      }
+    );
+
+    return ApiResponse.ok(res, "User signed in successfully!");
+  }
+);
+
+//? GET USER PROFILE
+export const getUserProfile = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const currentSessionId = req.user?.sessionId;
+
+    if (!userId || !currentSessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const user = await authService.getUserProfile(userId.toString());
+    if (!user) {
+      return next(ApiError.notFound("User not found"));
+    }
+
+    if (user.isDeleted) {
+      return next(ApiError.notFound("This account has been deactivated."));
+    }
+
+    const result = await authService.getUserSessions(
+      userId.toString(),
+      currentSessionId
+    );
+
+    if (!result) {
+      return next(ApiError.server("Failed to get user sessions!"));
+    }
+
+    return ApiResponse.ok(res, "User profile fetched successfully", {
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        avatar: user.avatar,
+        isEmailVerified: user.isEmailVerified,
+        lastLoginAt: user.lastLoginAt,
+        sessions: result
+      }
+    });
+  }
+);
+
+//? UPDATE PROFILE
+export const updateProfile = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const data = req.body;
+    const { name } = data;
+
+    if (!req.user?.id) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const user = await authService.getUserProfile(req.user?.id.toString());
+
+    if (!user) {
+      return next(ApiError.notFound("User not found"));
+    }
+
+    const avatar = user.avatar as AvatarData | null;
+    let updatedAvatar: AvatarData | null = avatar;
+
+    if (req?.file) {
+      const file = await uploadToCloudinary(req.file.buffer, {
+        folder: "uploads/files",
+        resource_type: "auto"
+      });
+      updatedAvatar = {
+        public_id: file.public_id,
+        url: file.url,
+        size: file.size
+      };
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (name) updateData.name = name;
+    if (updatedAvatar !== avatar) updateData.avatar = updatedAvatar;
+
+    if (Object.keys(updateData).length > 0) {
+      await db.update(users).set(updateData).where(eq(users.id, user.id));
+    }
+
+    if (avatar?.public_id && avatar.public_id !== updatedAvatar?.public_id) {
+      await deleteFileFromCloudinary([avatar.public_id]);
+    }
+
+    const updatedUser = await authService.getUserProfile(user.id.toString());
+
+    return ApiResponse.Success(res, "Profile updated successfully!", {
+      user: {
+        id: updatedUser?.id,
+        name: updatedUser?.name,
+        email: updatedUser?.email,
+        role: updatedUser?.role,
+        avatar: updatedUser?.avatar,
+        isEmailVerified: updatedUser?.isEmailVerified,
+        lastLoginAt: updatedUser?.lastLoginAt
+      }
+    });
+  }
+);
+
+//? REFRESH TOKENS
+export const refreshToken = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const accessToken = req.cookies?.accessToken;
+    const refreshToken = req.cookies?.refreshToken;
+
+    const token = await authService.refreshTokens(accessToken, refreshToken);
+
+    if (!token) {
+      return next(ApiError.server("Failed to refresh tokens!"));
+    }
+
+    const newAccessToken = token.accessToken;
+    const newRefreshToken = token.refreshToken;
+    setAuthCookies(res, newAccessToken, newRefreshToken, token.sessionId);
+
+    return ApiResponse.Success(res, "Tokens refreshed successfully!");
+  }
+);
+
+//? LOGOUT
+export const logoutUser = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req.user?.id;
+    if (!userId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const currentSessionId = req.user?.sessionId;
+    if (!currentSessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    await authService.logoutUser(userId.toString(), currentSessionId);
+
+    clearAuthCookies(res);
+
+    return ApiResponse.Success(res, "Logged out successfully!");
+  }
+);
+
+//? FORGOT PASSWORD
+export const forgotPassword = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email } = req.body;
+    if (!email) {
+      return next(ApiError.badRequest("Email is required!"));
+    }
+
+    await authService.forgotPassword(email);
+
+    return ApiResponse.ok(
+      res,
+      "If an account exists, a reset code has been sent to your email."
+    );
+  }
+);
+
+//? VERIFY RESET PASSWORD TOKEN
+export const verifyResetPasswordOtp = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { otpCode, email } = req.body;
+    if (!otpCode || !email) {
+      return next(ApiError.badRequest("OtpCode and email are required!"));
+    }
+
+    await authService.verifyResetPasswordOtp(otpCode, email);
+
+    return ApiResponse.ok(
+      res,
+      "Password reset otp verified successfully. You can now reset your password."
+    );
+  }
+);
+
+//? RESET PASSWORD
+export const resetPassword = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const { newPassword, email } = req.body;
+    if (!email || !newPassword) {
+      return next(ApiError.badRequest("Newpassword and email are required!"));
+    }
+
+    const result = await authService.resetPassword(email, newPassword);
+
+    if (!result) {
+      return next(ApiError.server("Failed to reset password!"));
+    }
+
+    clearAuthCookies(res);
+
+    return ApiResponse.ok(
+      res,
+      result.message || "Password reset successfully!"
+    );
+  }
+);
+
+//? CHANGE PASSWORD
+export const changePassword = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+
+    if (!userId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const { oldPassword, newPassword } = req.body;
+
+    if (!oldPassword || !newPassword) {
+      return next(
+        ApiError.badRequest("Old password and new password are required")
+      );
+    }
+
+    const result = await authService.changePassword({
+      userId: userId.toString(),
+      oldPassword,
+      newPassword
+    });
+
+    if (!result) {
+      return next(ApiError.server("Failed to change password!"));
+    }
+
+    clearAuthCookies(res);
+
+    return ApiResponse.ok(
+      res,
+      result.message || "Password changed successfully!"
+    );
+  }
+);
+
+//? REQUEST DELETE ACCOUNT
+export const requestDeleteAccount = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const { password } = req.body;
+
+    if (!userId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    if (!password) {
+      return next(ApiError.badRequest("Password is required!"));
+    }
+
+    await authService.requestDeleteAccount(userId, password);
+
+    return ApiResponse.ok(
+      res,
+      "Account deletion request sent successfully. Please check your email to confirm."
+    );
+  }
+);
+
+//? DELETE/DEACTIVATE ACCOUNT
+export const deleteAccount = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const { userId, type }: DeleteAccountType = req.body;
+
+    if (!userId || !type) {
+      return next(ApiError.badRequest("User id and type are required!"));
+    }
+
+    const reqUserId = req?.user?.id;
+
+    if (!reqUserId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+    const token = req.query.token as string;
+    if (!token) {
+      return next(
+        ApiError.badRequest(
+          `${type === "hard" ? "Delete" : "Deactivate"} account token is required!`
+        )
+      );
+    }
+
+    if (userId !== reqUserId.toString()) {
+      return next(
+        ApiError.unauthorized("You are not authorized to perform this action")
+      );
+    }
+
+    await authService.deleteOrDeactiveAccount({ userId, type, token });
+
+    clearAuthCookies(res);
+
+    return ApiResponse.Success(
+      res,
+      `Account ${type === "soft" ? "deactivated" : "deleted"} successfully!`
+    );
+  }
+);
+
+//? REACTIVATE ACCOUNT
+export const reactivateAccount = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+
+    if (!userId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    await authService.reactivateAccount(userId);
+
+    return ApiResponse.Success(res, "Account reactivated successfully!");
+  }
+);
+
+//? GET USER SESSIONS
+export const getUserSessions = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const currentSessionId = req.user?.sessionId;
+
+    if (!userId || !currentSessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const result = await authService.getUserSessions(
+      userId.toString(),
+      currentSessionId
+    );
+
+    if (!result) {
+      return next(ApiError.server("Failed to get user sessions!"));
+    }
+
+    return ApiResponse.ok(res, "User sessions fetched successfully", result);
+  }
+);
+
+//? DELETE SESSION
+export const deleteUserSession = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const { sessionId } = req.params;
+
+    if (!userId || !sessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    await authService.deleteSession(userId, sessionId as string);
+
+    const reqSId = req.cookies?.sid;
+
+    const isCurrentSession = sessionId === reqSId;
+    if (isCurrentSession) {
+      clearAuthCookies(res);
+    }
+
+    return ApiResponse.Success(res, "User session deleted successfully!");
+  }
+);
+
+//? DELETE ALL SESSIONS
+export const deleteAllUserSessions = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const currentSessionId = req.user?.sessionId;
+
+    if (!userId || !currentSessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    await authService.deleteAllUserSessions(userId);
+
+    clearAuthCookies(res);
+
+    return ApiResponse.Success(res, "User sessions deleted successfully!");
+  }
+);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.helpers.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.helpers.ts
@@ -1,0 +1,19 @@
+import argon2 from "argon2";
+import { OTPType } from "./auth.interfaces";
+
+export async function hashPassword(password: string): Promise<string> {
+  return argon2.hash(password);
+}
+
+export async function verifyPassword(
+  password: string,
+  hash: string
+): Promise<boolean> {
+  return argon2.verify(hash, password);
+}
+
+export const buildRedisKey = (
+  email: string,
+  otpType: OTPType,
+  suffix: string
+) => `otp:${suffix}:${email}:${otpType}`;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.interfaces.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.interfaces.ts
@@ -1,0 +1,45 @@
+import { OTP_TYPES } from "./auth.constants";
+
+export type OTPType = (typeof OTP_TYPES)[number];
+
+export interface AvatarData {
+  public_id: string;
+  url: string;
+  size: number;
+}
+
+export interface IUser {
+  id: string;
+  name: string;
+  email: string;
+  password?: string;
+  role: "user" | "admin";
+  isEmailVerified: boolean;
+  lastLoginAt?: Date;
+  failedLoginAttempts: number;
+  lockUntil?: Date;
+  avatar?: AvatarData | string | null;
+  provider: "local" | "google" | "github";
+  providerId?: string;
+  isDeleted: boolean;
+  deletedAt?: Date;
+  reActivateAvailableAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface RefreshTokenData {
+  userId: string;
+  tokenHash: string;
+  expiresAt: Date;
+}
+
+export interface SessionData {
+  userId: string;
+  sessionId: string;
+  refreshTokenHash: string;
+  userAgent: string;
+  ip: string;
+  createdAt: Date;
+  expiresAt: Date;
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.repository.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.repository.ts
@@ -1,0 +1,104 @@
+import { IAvatar, NewUser, User, users } from "@/db";
+import db from "@/shared/configs/db";
+import { eq } from "drizzle-orm";
+import { SignupUserType } from "./auth.validation";
+import {
+  ProviderType,
+  UpdatePasswordType,
+  UpdateUserActivation
+} from "./auth.types";
+import { REACTIVATION_AVAILABLE_AT } from "./auth.constants";
+
+export class AuthRepository {
+  async findUserByEmail(email: string): Promise<User | null> {
+    const [user] = await db.select().from(users).where(eq(users.email, email));
+
+    return user;
+  }
+
+  async findUserById(id: number): Promise<User | null> {
+    const [user] = await db.select().from(users).where(eq(users.id, id));
+    return user;
+  }
+
+  async createNewUser(
+    user: Omit<SignupUserType, "confirmPassword"> & {
+      isEmailVerified?: boolean;
+      provider?: ProviderType;
+      providerId?: string;
+      avatar?: IAvatar;
+    }
+  ): Promise<{
+    id: number;
+  }> {
+    const [result] = await db
+      .insert(users)
+      .values({
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        password: user.password,
+        isEmailVerified: true,
+        ...(user.provider && { provider: user.provider }),
+        ...(user.avatar && { avatar: user.avatar }),
+        ...(user.providerId && { providerId: user.providerId })
+      })
+      .$returningId();
+
+    return result;
+  }
+
+  async updateUser(user: Partial<User>, userId: number) {
+    const [result] = await db
+      .update(users)
+      .set(user)
+      .where(eq(users.id, userId));
+
+    return result;
+  }
+
+  async updateLoginAttempts({
+    failedLoginAttempts,
+    lockUntil,
+    id
+  }: {
+    failedLoginAttempts: number;
+    lockUntil: Date | null;
+    id: number;
+  }) {
+    await db
+      .update(users)
+      .set({
+        failedLoginAttempts,
+        lockUntil
+      })
+      .where(eq(users.id, id));
+  }
+
+  async updatePassword({ email, password }: UpdatePasswordType) {
+    await db
+      .update(users)
+      .set({
+        password
+      })
+      .where(eq(users.email, email));
+  }
+
+  async updateUserActivation({
+    id,
+    deletedAt,
+    isDeleted,
+    reActivateAvailableAt
+  }: UpdateUserActivation) {
+    await db
+      .update(users)
+      .set({
+        isDeleted,
+        deletedAt,
+        reActivateAvailableAt
+      })
+      .where(eq(users.id, id));
+  }
+}
+
+export const authRepository = new AuthRepository();

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.routes.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.routes.ts
@@ -1,0 +1,148 @@
+import { Router } from "express";
+import { validateRequest } from "@/shared/middlewares/validate-request";
+import {
+  ChangePasswordSchema,
+  DeleteAccountSchema,
+  RequestOtpSchema,
+  ResetPasswordSchema,
+  SigninSchema,
+  SignupSchema,
+  UpdateProfileSchema,
+  VerifyOtpSchema
+} from "./auth.validation";
+import {
+  changePassword,
+  deleteAccount,
+  deleteAllUserSessions,
+  deleteUserSession,
+  forgotPassword,
+  getUserProfile,
+  getUserSessions,
+  logoutUser,
+  reactivateAccount,
+  refreshToken,
+  requestDeleteAccount,
+  resetPassword,
+  signinUser,
+  signupUser,
+  updateProfile,
+  verifyResetPasswordOtp,
+  verifyUser
+} from "./auth.controller";
+import { verifyAuthentication } from "@/shared/middlewares/verify-auth";
+import { checkUserAccountRestriction } from "@/shared/middlewares/user-account-restriction";
+import {
+  changePasswordLimiter,
+  deleteAccountLimiter,
+  otpRequestLimiter,
+  resetPasswordLimiter,
+  signinRateLimiter,
+  signupRateLimiter
+} from "@/shared/middlewares/rate-limiter";
+import upload from "@/shared/middlewares/upload-file";
+
+const router = Router();
+
+router.post(
+  "/signup",
+  validateRequest(SignupSchema),
+  signupRateLimiter,
+  signupUser
+);
+
+router.post("/verify-user", validateRequest(VerifyOtpSchema), verifyUser);
+
+router.post(
+  "/signin",
+  validateRequest(SigninSchema),
+  signinRateLimiter,
+  signinUser
+);
+
+router.get("/profile", verifyAuthentication, getUserProfile);
+
+router.patch(
+  "/profile",
+  upload.single("avatar"),
+  validateRequest(UpdateProfileSchema),
+  verifyAuthentication,
+  checkUserAccountRestriction,
+  updateProfile
+);
+
+router.get("/sessions", verifyAuthentication, getUserSessions);
+
+router.delete(
+  "/sessions",
+  verifyAuthentication,
+  checkUserAccountRestriction,
+  deleteAllUserSessions
+);
+
+router.delete(
+  "/sessions/:sessionId",
+  verifyAuthentication,
+  checkUserAccountRestriction,
+  deleteUserSession
+);
+
+router.post("/refresh-token", refreshToken);
+
+router.post(
+  "/logout",
+  verifyAuthentication,
+  checkUserAccountRestriction,
+  logoutUser
+);
+
+router.post(
+  "/forgot-password",
+  validateRequest(RequestOtpSchema.pick({ email: true })),
+  otpRequestLimiter,
+  forgotPassword
+);
+
+router.post(
+  "/verify-reset-otp",
+  validateRequest(VerifyOtpSchema),
+  otpRequestLimiter,
+  verifyResetPasswordOtp
+);
+
+router.post(
+  "/reset-password",
+  validateRequest(ResetPasswordSchema),
+  resetPasswordLimiter,
+  resetPassword
+);
+
+router.post(
+  "/change-password",
+  verifyAuthentication,
+  validateRequest(ChangePasswordSchema),
+  checkUserAccountRestriction,
+  changePasswordLimiter,
+  changePassword
+);
+
+router.post(
+  "/account/request-delete",
+  verifyAuthentication,
+  validateRequest(SigninSchema.pick({ password: true })),
+  checkUserAccountRestriction,
+  deleteAccountLimiter,
+  requestDeleteAccount
+);
+
+router.delete(
+  "/account/delete",
+  verifyAuthentication,
+  validateRequest(DeleteAccountSchema),
+  checkUserAccountRestriction,
+  deleteAccountLimiter,
+  deleteAccount
+);
+
+router.put("/account/reactivate", verifyAuthentication, reactivateAccount);
+
+export default router;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.service.ts
@@ -1,0 +1,835 @@
+import { NextFunction } from "express";
+import db from "@/shared/configs/db";
+import { users } from "@/db/schemas/user.schema";
+import { eq } from "drizzle-orm";
+import { ApiError } from "@/shared/utils/api-error";
+import { hashPassword, verifyPassword } from "@/modules/auth/auth.helpers";
+import { SignupUserType, VerifyOtpType } from "./auth.validation";
+import {
+  DELETE_ACCOUNT_TOKEN_EXPIRY,
+  LOCK_TIME_MS,
+  LOGIN_MAX_ATTEMPTS,
+  OTP_CODE_LENGTH,
+  OTP_EXPIRES_IN,
+  REACTIVATION_AVAILABLE_AT,
+  REFRESH_TOKEN_EXPIRY,
+  RESET_PASSWORD_TOKEN_EXPIRY,
+  SESSION_EXPIRY
+} from "./auth.constants";
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  verifyAccessToken,
+  verifyRefreshToken
+} from "@/shared/utils/jwt";
+import {
+  generateHashedToken,
+  generateOTP,
+  generateSecureToken,
+  generateUUID
+} from "@/shared/helpers/token.helpers";
+import { AvatarData, RefreshTokenData, SessionData } from "./auth.interfaces";
+import { otpService, OtpService } from "../otp/otp.service";
+import { deleteFileFromCloudinary } from "../upload/upload.service";
+import redisClient from "@/shared/configs/redis";
+import { logger } from "@/shared/utils/logger";
+import env from "@/shared/configs/env";
+import { sendEmail } from "@/shared/utils/send-mail";
+import { getRemainingTime } from "@/shared/utils/date";
+import { AuthRepository, authRepository } from "./auth.repository";
+import { CookieOptionsType, UserSigninType } from "./auth.types";
+
+export class AuthService {
+  constructor(
+    private repo: AuthRepository,
+    private otpService: OtpService
+  ) {}
+
+  private async ensureUserChecks() {}
+
+  async registerUser(user: Omit<SignupUserType, "confirmPassword">) {
+    try {
+      const { name, email, password, role } = user;
+      const existingUser = await this.repo.findUserByEmail(email);
+
+      if (existingUser) {
+        throw ApiError.conflict("User with this email already exists");
+      }
+
+      const pending = await redisClient.get(`user:pending:${email}`);
+
+      if (pending) {
+        throw ApiError.conflict(
+          "Signup already in progress. Check your email for OTP."
+        );
+      }
+
+      const hashedPassword = await hashPassword(password);
+      await this.otpService.checkOtpRestrictions(email);
+      await this.otpService.trackOtpRequests(email);
+
+      const { code, hashCode } = generateOTP(OTP_CODE_LENGTH);
+
+      const redisKey = `user:${email}:${hashCode}`;
+      const indexKey = `user:pending:${email}`;
+      const userData = JSON.stringify({
+        name,
+        email,
+        role,
+        password: hashedPassword
+      });
+
+      await this.otpService.sendOtp({
+        name,
+        email,
+        templateName: "email-verification",
+        code,
+        hashCode,
+        subject: "Email Verification"
+      });
+
+      try {
+        await redisClient.set(redisKey, userData, {
+          expiration: {
+            type: "PX",
+            value: OTP_EXPIRES_IN
+          }
+        });
+
+        await redisClient.set(indexKey, hashCode, {
+          expiration: {
+            type: "PX",
+            value: OTP_EXPIRES_IN
+          }
+        });
+      } catch (error) {
+        await Promise.allSettled([
+          redisClient.del(redisKey),
+          redisClient.del(indexKey),
+          redisClient.del(`otp:${email}`),
+          redisClient.del(`otp_cooldown:${email}`)
+        ]);
+
+        throw error;
+      }
+    } catch (error) {
+      logger.error(error, "Failed to register user");
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw ApiError.server("Failed to register user");
+    }
+  }
+
+  async verifyUser({ email, otpCode }: VerifyOtpType) {
+    const hashCode = generateHashedToken(otpCode);
+
+    await this.otpService.verifyOtp(hashCode, email);
+
+    const userData = await redisClient.get(`user:${email}:${hashCode}`);
+
+    if (!userData) {
+      throw ApiError.badRequest("Invalid or expired otp");
+    }
+
+    const { name, email: userEmail, role, password } = JSON.parse(userData);
+
+    const user = await this.repo.createNewUser({
+      name,
+      email: userEmail,
+      role,
+      password
+    });
+
+    await redisClient.del(`user:${email}:${hashCode}`);
+    await redisClient.del(`user:pending:${email}`);
+
+    return {
+      _id: user.id,
+      name,
+      email,
+      role: role,
+      isEmailVerified: true
+    };
+  }
+
+  async signinUser(
+    { email, password, ip, userAgent }: UserSigninType,
+    setCookie: CookieOptionsType
+  ) {
+    try {
+      const user = await this.repo.findUserByEmail(email);
+
+      if (!user) {
+        throw ApiError.unauthorized("Invalid credentials");
+      }
+
+      if (!user.isEmailVerified) {
+        throw ApiError.unauthorized("Email not verified");
+      }
+
+      if (user.lockUntil && new Date() < user.lockUntil) {
+        throw ApiError.forbidden(
+          `Your account has been locked. Please try again after ${getRemainingTime(user.lockUntil).minutes} minutes and ${getRemainingTime(user.lockUntil).seconds} seconds.`
+        );
+      }
+
+      const isPasswordValid = await verifyPassword(
+        password,
+        user.password || ""
+      );
+      if (!isPasswordValid) {
+        let lockUntil = null;
+
+        let newAttempts = user.failedLoginAttempts + 1;
+
+        if (newAttempts >= LOGIN_MAX_ATTEMPTS) {
+          lockUntil = new Date(Date.now() + LOCK_TIME_MS);
+        }
+
+        await this.repo.updateLoginAttempts({
+          id: user.id,
+          lockUntil,
+          failedLoginAttempts: newAttempts
+        });
+        throw ApiError.unauthorized("Invalid credentials");
+      }
+
+      await this.repo.updateLoginAttempts({
+        id: user.id,
+        lockUntil: null,
+        failedLoginAttempts: 0
+      });
+
+      await this.handleToken(
+        {
+          _id: user.id,
+          role: user.role as "user" | "admin",
+          ip,
+          userAgent
+        },
+        setCookie
+      );
+
+      return {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        isEmailVerified: user.isEmailVerified
+      };
+    } catch (err) {
+      if (err instanceof ApiError) {
+        throw err;
+      }
+      throw ApiError.server("Signin failed");
+    }
+  }
+
+  async handleToken(
+    user: { _id: number; role: "user" | "admin" } & {
+      ip: string;
+      userAgent: string;
+    },
+    context: CookieOptionsType
+  ) {
+    const sessionId = generateUUID();
+
+    const accessToken = generateAccessToken({
+      _id: user._id.toString(),
+      role: user.role,
+      sessionId
+    });
+
+    const refreshToken = generateRefreshToken({
+      _id: user._id.toString(),
+      sessionId
+    });
+
+    const hashedRefreshToken = generateHashedToken(refreshToken);
+
+    const refreshTokenData: RefreshTokenData = {
+      userId: user._id.toString(),
+      tokenHash: hashedRefreshToken,
+      expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY)
+    };
+
+    const sessionData: SessionData = {
+      userId: user._id.toString(),
+      sessionId,
+      refreshTokenHash: hashedRefreshToken,
+      userAgent: user.userAgent,
+      ip: user.ip,
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + SESSION_EXPIRY)
+    };
+
+    const refreshTokenKey = `refreshToken:${hashedRefreshToken}`;
+
+    await redisClient.set(refreshTokenKey, JSON.stringify(refreshTokenData), {
+      expiration: {
+        type: "PX",
+        value: REFRESH_TOKEN_EXPIRY
+      }
+    });
+
+    const sessionKey = `session:${sessionId}`;
+
+    const userSessionsKey = `user_sessions:${user._id}`;
+
+    await redisClient.set(sessionKey, JSON.stringify(sessionData), {
+      expiration: {
+        type: "PX",
+        value: SESSION_EXPIRY
+      }
+    });
+
+    // add sessionId to user's set
+    await redisClient.sAdd(userSessionsKey, sessionId);
+
+    context.setAuthCookie &&
+      context.setAuthCookie(accessToken, refreshToken, sessionId);
+
+    await db
+      .update(users)
+      .set({
+        lastLoginAt: new Date(),
+        failedLoginAttempts: 0,
+        lockUntil: null
+      })
+      .where(eq(users.id, user._id));
+  }
+
+  async getUserProfile(userId: string) {
+    const user = await this.repo.findUserById(parseInt(userId));
+
+    return user;
+  }
+
+  async refreshTokens(accessToken: string | null, refreshToken: string) {
+    if (!refreshToken) {
+      throw ApiError.unauthorized("Unauthorized, please login.");
+    }
+
+    const decodedRefresh = verifyRefreshToken(refreshToken);
+
+    if (!decodedRefresh?._id) {
+      throw ApiError.unauthorized("Invalid refresh token.");
+    }
+
+    const refreshTokenHash = generateHashedToken(refreshToken);
+
+    const refreshTokenKey = `refreshToken:${refreshTokenHash}`;
+    const sessionKey = `session:${decodedRefresh.sessionId}`;
+
+    await redisClient.watch([refreshTokenKey, sessionKey]);
+
+    try {
+      const [storedToken, session] = await Promise.all([
+        redisClient.get(refreshTokenKey),
+        redisClient.get(sessionKey)
+      ]);
+
+      if (!storedToken) {
+        throw ApiError.unauthorized("Invalid refresh token.");
+      }
+
+      const { userId, tokenHash, expiresAt } = JSON.parse(
+        storedToken
+      ) as RefreshTokenData;
+
+      if (userId !== decodedRefresh._id || tokenHash !== refreshTokenHash) {
+        throw ApiError.unauthorized("Invalid refresh token.");
+      }
+
+      if (new Date(expiresAt) < new Date()) {
+        throw ApiError.unauthorized("Refresh token expired.");
+      }
+
+      if (!session) {
+        throw ApiError.unauthorized("Session not found.");
+      }
+
+      const storedSessionData = JSON.parse(session) as SessionData;
+
+      if (
+        decodedRefresh.sessionId !== storedSessionData.sessionId ||
+        decodedRefresh._id !== storedSessionData.userId ||
+        storedSessionData.refreshTokenHash !== refreshTokenHash
+      ) {
+        throw ApiError.unauthorized("Token-session mismatch");
+      }
+
+      if (accessToken) {
+        try {
+          const decodedAccess = verifyAccessToken(accessToken);
+          if (decodedAccess._id !== decodedRefresh._id) {
+            throw ApiError.unauthorized("Token mismatch.");
+          }
+        } catch (e) {
+          // Access token might be expired, which is normal for a refresh flow
+        }
+      }
+
+      const user = await this.repo.findUserById(parseInt(decodedRefresh._id));
+      if (!user) {
+        throw ApiError.unauthorized("User not found.");
+      }
+
+      const newAccessToken = generateAccessToken({
+        _id: user.id.toString(),
+        role: user.role as "user" | "admin",
+        sessionId: storedSessionData.sessionId
+      });
+
+      const newRefreshToken = generateRefreshToken({
+        _id: user.id.toString(),
+        sessionId: storedSessionData.sessionId
+      });
+      const newRefreshTokenHash = generateHashedToken(newRefreshToken);
+
+      const refreshTokenData: RefreshTokenData = {
+        userId: user.id.toString(),
+        tokenHash: newRefreshTokenHash,
+        expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY)
+      };
+      const sessionData: SessionData = {
+        userId: user.id.toString(),
+        sessionId: storedSessionData.sessionId,
+        refreshTokenHash: newRefreshTokenHash,
+        userAgent: storedSessionData.userAgent,
+        ip: storedSessionData.ip,
+        createdAt: storedSessionData.createdAt,
+        expiresAt: new Date(Date.now() + SESSION_EXPIRY)
+      };
+
+      const newRefreshTokenKey = `refreshToken:${newRefreshTokenHash}`;
+      const transaction = redisClient.multi();
+
+      transaction.del(`refreshToken:${tokenHash}`);
+      transaction.set(newRefreshTokenKey, JSON.stringify(refreshTokenData), {
+        expiration: {
+          type: "PX",
+          value: REFRESH_TOKEN_EXPIRY
+        }
+      });
+      transaction.set(sessionKey, JSON.stringify(sessionData), {
+        expiration: {
+          type: "PX",
+          value: SESSION_EXPIRY
+        }
+      });
+
+      const transactionResult = await transaction.exec();
+
+      if (!transactionResult) {
+        throw ApiError.unauthorized("Refresh token already rotated.");
+      }
+
+      return {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+        sessionId: storedSessionData.sessionId
+      };
+    } finally {
+      await redisClient.unwatch();
+    }
+  }
+
+  async logoutUser(userId: string, sessionId: string) {
+    const sessionKey = `session:${sessionId}`;
+    const sessionData = await redisClient.get(sessionKey);
+    const userSessionsKey = `user_sessions:${userId}`;
+    if (!sessionData) {
+      throw ApiError.unauthorized("Session not found.");
+    }
+
+    const session = JSON.parse(sessionData) as SessionData;
+
+    if (session.userId !== userId) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    const refreshTokenKey = `refreshToken:${session.refreshTokenHash}`;
+
+    await redisClient.del(sessionKey);
+    await redisClient.del(refreshTokenKey);
+    await redisClient.sRem(userSessionsKey, sessionId);
+  }
+
+  async forgotPassword(email: string) {
+    const user = await this.repo.findUserByEmail(email);
+
+    if (!user) {
+      return;
+    }
+
+    const { code, hashCode } = generateOTP(OTP_CODE_LENGTH);
+
+    await this.otpService.checkOtpRestrictions(email);
+    await this.otpService.trackOtpRequests(email);
+
+    const redisKey = `reset_password:${email}:${hashCode}`;
+
+    await redisClient.set(redisKey, hashCode, {
+      expiration: {
+        type: "PX",
+        value: RESET_PASSWORD_TOKEN_EXPIRY
+      }
+    });
+
+    await this.otpService.sendOtp({
+      email,
+      subject: "Password Reset",
+      templateName: "forgot-password",
+      name: user.name,
+      code,
+      hashCode
+    });
+  }
+
+  async verifyResetPasswordOtp(otpCode: string, email: string) {
+    const hashedCode = generateHashedToken(otpCode);
+
+    const redisKey = `reset_password:${email}:${hashedCode}`;
+    const storedHashCode = await redisClient.get(redisKey);
+    if (!storedHashCode) {
+      throw ApiError.unauthorized("Invalid or expired otp");
+    }
+    await this.otpService.verifyOtp(storedHashCode, email);
+
+    await redisClient.del(`reset_password:${email}:${hashedCode}`);
+    await redisClient.set(`reset_password:status:${email}`, "pending", {
+      expiration: {
+        type: "PX",
+        value: RESET_PASSWORD_TOKEN_EXPIRY
+      }
+    });
+  }
+
+  async getUserSessions(userId: string, currentSessionId: string) {
+    const userSessionsKey = `user_sessions:${userId}`;
+    const sessionIds = await redisClient.sMembers(userSessionsKey);
+
+    const sessions = [];
+    for (const sessionId of sessionIds) {
+      const sessionKey = `session:${sessionId}`;
+      const sessionData = await redisClient.get(sessionKey);
+      if (sessionData) {
+        const session = JSON.parse(sessionData) as SessionData;
+        sessions.push({
+          ...session,
+          isCurrent: sessionId === currentSessionId
+        });
+      }
+    }
+
+    return sessions;
+  }
+
+  async deleteSession(userId: string, sessionId: string) {
+    const sessionKey = `session:${sessionId}`;
+    const sessionData = await redisClient.get(sessionKey);
+    const userSessionsKey = `user_sessions:${userId}`;
+
+    if (!sessionData) {
+      throw ApiError.notFound("Session not found.");
+    }
+
+    const session = JSON.parse(sessionData) as SessionData;
+
+    if (session.userId !== userId) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    const refreshTokenKey = `refreshToken:${session.refreshTokenHash}`;
+
+    await redisClient.del(sessionKey);
+    await redisClient.del(refreshTokenKey);
+    await redisClient.sRem(userSessionsKey, sessionId);
+  }
+
+  async deleteAllUserSessions(userId: string) {
+    const userSessionsKey = `user_sessions:${userId}`;
+    const sessionIds = await redisClient.sMembers(userSessionsKey);
+
+    if (sessionIds.length === 0) {
+      return;
+    }
+
+    const sessions = await Promise.all(
+      sessionIds.map(async sessionId => {
+        const sessionKey = `session:${sessionId}`;
+        const sessionData = await redisClient.get(sessionKey);
+
+        return {
+          sessionKey,
+          session: sessionData ? (JSON.parse(sessionData) as SessionData) : null
+        };
+      })
+    );
+
+    await Promise.all(
+      sessions.flatMap(({ sessionKey, session }) => {
+        const deletions = [redisClient.del(sessionKey)];
+
+        if (session?.refreshTokenHash) {
+          deletions.push(
+            redisClient.del(`refreshToken:${session.refreshTokenHash}`)
+          );
+        }
+
+        return deletions;
+      })
+    );
+
+    await redisClient.del(userSessionsKey);
+  }
+
+  async resetPassword(email: string, newPassword: string) {
+    const user = await this.repo.findUserByEmail(email);
+
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    if (user.lockUntil && new Date(user.lockUntil) > new Date()) {
+      throw ApiError.forbidden(
+        `Your account has been locked. Please try again after ${
+          getRemainingTime(user.lockUntil).minutes
+        } minutes and ${getRemainingTime(user.lockUntil).seconds} seconds.`
+      );
+    }
+
+    if (user.failedLoginAttempts >= LOGIN_MAX_ATTEMPTS && user.lockUntil) {
+      throw ApiError.forbidden(
+        `You have exceeded the maximum number of login attempts. Please try again after ${
+          getRemainingTime(user.lockUntil).minutes
+        } minutes and ${getRemainingTime(user.lockUntil).seconds} seconds.`
+      );
+    }
+
+    if (!user.isEmailVerified) {
+      throw ApiError.unauthorized("Please verify your email first.");
+    }
+
+    const redisKey = `reset_password:status:${email}`;
+    const status = await redisClient.get(redisKey);
+    if (status !== "pending") {
+      throw ApiError.unauthorized(
+        "Please request a password reset before attempting to set a new password."
+      );
+    }
+
+    const oldPassword = user.password;
+
+    const isOldPassword = await verifyPassword(
+      newPassword,
+      oldPassword as string
+    );
+
+    if (isOldPassword) {
+      throw ApiError.badRequest("New password should be different!");
+    }
+
+    const hashedPassword = await hashPassword(newPassword);
+
+    await this.repo.updatePassword({
+      email,
+      password: hashedPassword
+    });
+
+    await redisClient.del(`reset_password:status:${email}`);
+
+    //? Delete all user sessions
+    await this.deleteAllUserSessions(user.id.toString());
+
+    return {
+      message: "Password reset successfully. Please login!"
+    };
+  }
+
+  async changePassword({
+    newPassword,
+    oldPassword,
+    userId
+  }: {
+    userId: string;
+    newPassword: string;
+    oldPassword: string;
+  }) {
+    const user = await this.repo.findUserById(parseInt(userId));
+
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    if (!user.isEmailVerified) {
+      throw ApiError.unauthorized("Please verify your email first.");
+    }
+
+    const isOldPassword = await verifyPassword(
+      oldPassword,
+      user.password || ""
+    );
+
+    if (!isOldPassword) {
+      throw ApiError.unauthorized("Invalid credentials");
+    }
+
+    if (newPassword === oldPassword) {
+      throw ApiError.badRequest("New password should be different!");
+    }
+
+    const hashedPassword = await hashPassword(newPassword);
+    await this.repo.updatePassword({
+      email: user.email,
+      password: hashedPassword
+    });
+
+    await this.deleteAllUserSessions(userId);
+
+    return {
+      message: "Password changed successfully. Please login again!"
+    };
+  }
+
+  async requestDeleteAccount(userId: string, password: string) {
+    const user = await this.repo.findUserById(parseInt(userId));
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    const isPasswordValid = await verifyPassword(password, user.password || "");
+
+    if (!isPasswordValid) {
+      let lockUntil = null;
+
+      let newAttempts = user.failedLoginAttempts + 1;
+
+      if (newAttempts >= LOGIN_MAX_ATTEMPTS) {
+        lockUntil = new Date(Date.now() + LOCK_TIME_MS);
+      }
+
+      await this.repo.updateLoginAttempts({
+        id: user.id,
+        failedLoginAttempts: newAttempts,
+        lockUntil
+      });
+      throw ApiError.unauthorized("Invalid credentials");
+    }
+
+    const token = generateSecureToken();
+    const hashedToken = generateHashedToken(token);
+
+    const redisKey = `delete_account:token:${userId}`;
+
+    if (await redisClient.get(redisKey)) {
+      throw ApiError.badRequest("Delete account token already requested!");
+    }
+
+    await redisClient.set(redisKey, hashedToken, {
+      expiration: {
+        type: "PX",
+        value: DELETE_ACCOUNT_TOKEN_EXPIRY
+      }
+    });
+
+    const deleteAccountUrl = `${env.CLIENT_URL}/account/delete?token=${token}`;
+    logger.info({ userId, token }, "Delete account email queued");
+    await sendEmail({
+      email: user.email,
+      subject: "Delete Account Request",
+      templateName: "delete-account",
+      data: {
+        name: user.name,
+        deleteAccountUrl
+      }
+    });
+  }
+
+  async deleteOrDeactiveAccount({
+    userId,
+    type,
+    token
+  }: {
+    userId: string;
+    type: "soft" | "hard";
+    token: string;
+  }) {
+    const user = await this.repo.findUserById(parseInt(userId));
+
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    const redisKey = `delete_account:token:${userId}`;
+    const storedToken = await redisClient.get(redisKey);
+    if (!storedToken) {
+      throw ApiError.badRequest("Invalid or expired token!");
+    }
+
+    const isTokenValid = generateHashedToken(token) === storedToken;
+    if (!isTokenValid) {
+      throw ApiError.badRequest("Invalid or expired token!");
+    }
+
+    await redisClient.del(redisKey);
+
+    if (type === "soft") {
+      await this.repo.updateUserActivation({
+        id: parseInt(userId),
+        isDeleted: true,
+        deletedAt: new Date(),
+        reActivateAvailableAt: new Date(Date.now() + REACTIVATION_AVAILABLE_AT)
+      });
+      await this.deleteAllUserSessions(userId);
+    } else if (type === "hard") {
+      const avatar = user.avatar as AvatarData | string | null | undefined;
+
+      if (avatar && typeof avatar !== "string" && avatar.public_id) {
+        await deleteFileFromCloudinary([avatar.public_id]);
+      }
+      await db.delete(users).where(eq(users.id, parseInt(userId)));
+      await this.deleteAllUserSessions(userId);
+    }
+  }
+
+  async reactivateAccount(userId: string) {
+    const user = await this.repo.findUserById(parseInt(userId));
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    if (user.lockUntil && new Date(user.lockUntil) > new Date()) {
+      const remainingTime = getRemainingTime(user.lockUntil);
+      throw ApiError.badRequest(
+        `Your account has been locked. Please try again after ${remainingTime.minutes} minutes and ${remainingTime.seconds} seconds.`
+      );
+    }
+
+    if (!user?.isDeleted || !user?.deletedAt) {
+      throw ApiError.badRequest("Your account is already active!");
+    }
+
+    if (
+      user?.reActivateAvailableAt &&
+      new Date(user?.reActivateAvailableAt) > new Date()
+    ) {
+      throw ApiError.forbidden(
+        `Your account has been locked. Please try again after ${
+          getRemainingTime(user.reActivateAvailableAt).minutes
+        } minutes and ${getRemainingTime(user.reActivateAvailableAt).seconds} seconds.`
+      );
+    }
+
+    await this.repo.updateUserActivation({
+      id: parseInt(userId),
+      isDeleted: false,
+      deletedAt: null,
+      reActivateAvailableAt: null
+    });
+  }
+}
+
+export const authService = new AuthService(authRepository, otpService);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.types.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.types.ts
@@ -1,0 +1,28 @@
+export type CookieOptionsType = {
+  setAuthCookie?: (
+    accessToken: string,
+    refreshToken: string,
+    sessionId: string
+  ) => void;
+};
+
+export type UserSigninType = {
+  email: string;
+  password: string;
+  ip: string;
+  userAgent: string;
+};
+
+export type UpdatePasswordType = {
+  email: string;
+  password: string;
+};
+
+export type UpdateUserActivation = {
+  id: number;
+  deletedAt: Date | null;
+  reActivateAvailableAt: Date | null;
+  isDeleted: boolean;
+};
+
+export type ProviderType = "local" | "google" | "github" | "facebook";

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.validation.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/auth/auth.validation.ts
@@ -1,0 +1,113 @@
+import * as z from "zod";
+import { OTP_TYPES } from "../../modules/auth/auth.constants";
+
+export const nameSchema = z
+  .string({ error: "Name must be a string" })
+  .trim()
+  .min(3, {
+    message: "Name must be at least 3 characters long"
+  })
+  .max(50, {
+    message: "Name must be at most 50 characters long"
+  });
+
+export const passwordSchema = z
+  .string({ error: "Password must be a string" })
+  .min(6, {
+    message: "Password must be at least 6 characters long"
+  })
+  .max(80, {
+    message: "Password must be at most 80 characters long"
+  });
+
+export const emailSchema = z
+  .email({ message: "Please enter a valid email address." })
+  .max(100, { message: "Email must be no more than 100 characters." });
+
+export const roleSchema = z
+  .enum(["user", "admin"], {
+    error: "Role must be either applicant, recruiter, or admin"
+  })
+  .default("user");
+
+export const SigninSchema = z.object({
+  email: emailSchema,
+  password: z.string({ error: "Password must be a string" }).min(1, {
+    message: "Password is required"
+  })
+});
+
+export const SignupSchema = z
+  .object({
+    name: nameSchema,
+    email: emailSchema,
+    password: passwordSchema,
+    confirmPassword: passwordSchema,
+    role: roleSchema
+  })
+  .refine(
+    data => {
+      return data.password === data.confirmPassword;
+    },
+    {
+      message: "Passwords do not match",
+      path: ["confirmPassword"]
+    }
+  );
+
+export const RequestOtpSchema = z.object({
+  email: emailSchema,
+  otpType: z.enum(OTP_TYPES, { error: "Invalid otp type" })
+});
+
+export const VerifyOtpSchema = z.object({
+  otpCode: z.string().min(6, "Please enter a valid OTP"),
+  email: emailSchema
+});
+
+export const ResetPasswordSchema = z.object({
+  email: emailSchema,
+  newPassword: passwordSchema
+});
+
+export const ChangePasswordSchema = z.object({
+  oldPassword: z.string({ error: "Password must be a string" }).min(1, {
+    message: "Old password is required"
+  }),
+  newPassword: passwordSchema
+});
+
+export const UpdateProfileSchema = z.object({
+  name: nameSchema.optional(),
+  avatar: z.string().optional()
+});
+
+export const GoogleSigninSchema = z.object({
+  name: nameSchema,
+  email: emailSchema,
+  provider: z.enum(["google", "github"]).default("google"),
+  providerId: z.string({ error: "Provider id must be a string" }).min(1, {
+    message: "Provider id is required"
+  }),
+  avatar: z.string().optional(),
+  isEmailVerified: z.boolean().default(false)
+});
+
+export const DeleteAccountSchema = z.object({
+  userId: z.string({ error: "User id must be a string" }).min(1, {
+    message: "User id is required"
+  }),
+  type: z
+    .enum(["soft", "hard"], { error: "Type must be either soft or hard" })
+    .default("soft")
+});
+
+export type SignupUserType = z.infer<typeof SignupSchema>;
+export type SigninUserType = z.infer<typeof SigninSchema>;
+export type RequestOtpType = z.infer<typeof RequestOtpSchema>;
+export type VerifyOtpType = z.infer<typeof VerifyOtpSchema>;
+export type ResetPasswordType = z.infer<typeof ResetPasswordSchema>;
+export type ChangePasswordType = z.infer<typeof ChangePasswordSchema>;
+export type UpdateProfileType = z.infer<typeof UpdateProfileSchema>;
+export type GoogleSigninType = z.infer<typeof GoogleSigninSchema>;
+export type DeleteAccountType = z.infer<typeof DeleteAccountSchema>;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/health/health.controller.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/health/health.controller.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from "express";
+import { ApiResponse } from "@/shared/utils/api-response";
+import { AsyncHandler } from "@/shared/utils/async-handler";
+
+export const healthCheck = AsyncHandler(
+  async (_req: Request, res: Response) => {
+    const healthData = {
+      status: "healthy",
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      environment: process.env.NODE_ENV || "development",
+      version: process.env.npm_package_version || "1.0.0",
+      memory: {
+        used:
+          Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 100) /
+          100,
+        total:
+          Math.round((process.memoryUsage().heapTotal / 1024 / 1024) * 100) /
+          100,
+        unit: "MB"
+      },
+      cpu: {
+        usage: process.cpuUsage()
+      }
+    };
+    return ApiResponse.Success(res, "Service is healthy", healthData);
+  }
+);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/health/health.routes.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/health/health.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { healthCheck } from "./health.controller";
+
+const router = Router();
+
+router.get("/", healthCheck);
+
+export default router;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/oauth/oauth.controller.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/oauth/oauth.controller.ts
@@ -1,0 +1,102 @@
+import { NextFunction, Request, Response } from "express";
+import { Profile as GithubProfile } from "passport-github2";
+import { Profile as GoogleProfile } from "passport-google-oauth20";
+
+import { ApiResponse } from "@/shared/utils/api-response";
+import { AsyncHandler } from "@/shared/utils/async-handler";
+import { ApiError } from "@/shared/utils/api-error";
+import { oauthService } from "@/modules/oauth/oauth.service";
+import { setAuthCookies } from "@/shared/helpers/cookie.helper";
+
+//? LOGIN WITH GITHUB
+export const githubOAuth = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const data = req.user as GithubProfile | undefined;
+
+    if (!data) {
+      return next(ApiError.unauthorized("Authenticated failed!"));
+    }
+
+    const user = {
+      provider: data?.provider as "local" | "google" | "github",
+      providerId: data.id,
+      name: data.displayName,
+      email: data?.emails && data?.emails[0]?.value,
+      isEmailVerified: true,
+      avatar: data.photos && data.photos[0].value,
+      ip: req.ip || "Unknown",
+      userAgent: req.get("user-agent") || req.headers["user-agent"] || "Unknown"
+    };
+
+    const existingUser = await oauthService.handleOAuthLogin(user, {
+      setAuthCookie: (
+        accessToken: string,
+        refreshToken: string,
+        sessionId: string
+      ) => {
+        setAuthCookies(res, accessToken, refreshToken, sessionId);
+      }
+    });
+
+    //? save the data into your databases
+
+    ApiResponse.ok(res, "Signin Successfull", {
+      user: {
+        id: existingUser.id,
+        name: existingUser.name,
+        email: existingUser.email,
+        role: existingUser.role,
+        avatar: existingUser.avatar,
+        isEmailVerified: existingUser.isEmailVerified,
+        lastLoginAt: existingUser.lastLoginAt,
+        provider: existingUser.provider
+      }
+    });
+  }
+);
+
+//? LOGIN WITH GOOGLE
+export const googleOAuth = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const data = req.user as GoogleProfile | undefined;
+
+    if (!data) {
+      return next(ApiError.unauthorized("Authenticated failed!"));
+    }
+
+    const userInfo = {
+      provider: data?.provider as "local" | "google" | "github",
+      providerId: data.id,
+      name: data.displayName,
+      email: data?.emails && data?.emails[0]?.value,
+      isEmailVerified:
+        (data?.emails && data?.emails[0]?.verified === true) || true,
+      avatar: data.profileUrl || (data.photos && data.photos[0].value),
+      ip: req.ip || "Unknown",
+      userAgent: req.get("user-agent") || req.headers["user-agent"] || "Unknown"
+    };
+
+    const existingUser = await oauthService.handleOAuthLogin(userInfo, {
+      setAuthCookie: (
+        accessToken: string,
+        refreshToken: string,
+        sessionId: string
+      ) => {
+        setAuthCookies(res, accessToken, refreshToken, sessionId);
+      }
+    });
+
+    ApiResponse.ok(res, "Signin Successfull", {
+      user: {
+        id: existingUser.id,
+        name: existingUser.name,
+        email: existingUser.email,
+        role: existingUser.role,
+        avatar: existingUser.avatar,
+        isEmailVerified: existingUser.isEmailVerified,
+        lastLoginAt: existingUser.lastLoginAt,
+        provider: existingUser.provider
+      }
+    });
+  }
+);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/oauth/oauth.routes.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/oauth/oauth.routes.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+import passport from "passport";
+import { githubOAuth, googleOAuth } from "./oauth.controller";
+
+const router = Router();
+
+router.get(
+  "/github",
+  passport.authenticate("github", { scope: ["user:email"] })
+);
+
+router.get(
+  "/github/callback",
+  passport.authenticate("github", {
+    failureRedirect: "/login", //? redirect route if authenticated is failed,
+    session: false
+  }),
+  githubOAuth
+);
+
+router.get(
+  "/google",
+  passport.authenticate("google", {
+    scope: ["email", "profile", "openid"],
+    prompt: "consent"
+  })
+);
+
+router.get(
+  "/google/callback",
+  passport.authenticate("google", {
+    failureRedirect: "/login", //? redirect route if authenticated is failed
+    session: false
+  }),
+  googleOAuth
+);
+
+export default router;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/oauth/oauth.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/oauth/oauth.service.ts
@@ -1,0 +1,103 @@
+import db from "@/shared/configs/db";
+import { users } from "@/db/schemas/user.schema";
+import { ApiError } from "@/shared/utils/api-error";
+import { authService, AuthService } from "../auth/auth.service";
+import { CookieOptionsType, ProviderType } from "../auth/auth.types";
+import { authRepository, AuthRepository } from "../auth/auth.repository";
+
+type OAuthProfile = {
+  provider: ProviderType;
+  providerId: string;
+  name: string;
+  email: string | undefined;
+  isEmailVerified: boolean;
+  avatar: string | undefined;
+  ip: string;
+  userAgent: string;
+};
+
+export class OAuthService {
+  constructor(
+    private authService: AuthService,
+    private repo: AuthRepository
+  ) {}
+
+  async handleOAuthLogin(user: OAuthProfile, context: CookieOptionsType) {
+    if (!user.email) {
+      throw new Error("Email is required for OAuth login");
+    }
+
+    const existingUser = await this.repo.findUserByEmail(user.email);
+
+    if (existingUser) {
+      const canAutoLinkProvider =
+        user.isEmailVerified || existingUser.provider === user.provider;
+
+      if (!canAutoLinkProvider) {
+        throw ApiError.forbidden(
+          "Please sign in with your existing provider to link this account."
+        );
+      }
+
+      await this.repo.updateUser(
+        {
+          provider: user.provider,
+          providerId: user.providerId,
+          isEmailVerified: existingUser.isEmailVerified || user.isEmailVerified,
+          avatar: user.avatar ? { url: user.avatar } : null
+        },
+        existingUser.id
+      );
+      await this.authService.handleToken(
+        {
+          _id: existingUser.id,
+          role: existingUser.role,
+          ip: user.ip,
+          userAgent: user.userAgent
+        },
+        context
+      );
+      return existingUser;
+    }
+
+    const result = await this.repo.createNewUser({
+      name: user.name,
+      email: user.email,
+      isEmailVerified: user.isEmailVerified,
+      provider: user.provider,
+      providerId: user.providerId,
+      password: "",
+      role: "user",
+      avatar: user.avatar ? { url: user.avatar } : undefined
+    });
+
+    await this.authService.handleToken(
+      {
+        _id: result.id,
+        role: "user",
+        ip: user.ip,
+        userAgent: user.userAgent
+      },
+      context
+    );
+
+    const newUser = await this.repo.findUserById(result.id);
+
+    if (!newUser) {
+      throw ApiError.server("Failed to login");
+    }
+
+    return {
+      id: newUser.id,
+      name: newUser.name,
+      email: newUser.email,
+      role: newUser.role,
+      avatar: newUser.avatar,
+      isEmailVerified: newUser.isEmailVerified,
+      provider: newUser.provider,
+      lastLoginAt: new Date()
+    };
+  }
+}
+
+export const oauthService = new OAuthService(authService, authRepository);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/otp/otp.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/otp/otp.service.ts
@@ -1,0 +1,178 @@
+import { logger } from "@/shared/utils/logger";
+import redis from "@/shared/configs/redis";
+import {
+  OTP_CODE_LENGTH,
+  OTP_EXPIRES_IN,
+  OTP_MAX_ATTEMPTS,
+  OTP_SPAM_LOCK_TIME,
+  OTP_COOL_DOWN
+} from "../auth/auth.constants";
+import { generateOTP } from "@/shared/helpers/token.helpers";
+import { ApiError } from "@/shared/utils/api-error";
+import { sendEmail } from "@/shared/utils/send-mail";
+
+type SendOtpBase = {
+  name: string;
+  email: string;
+  templateName: string;
+  subject: string;
+};
+
+type SendOtpWithCode = SendOtpBase & {
+  code: string;
+  hashCode: string;
+};
+
+type SendOtpWithoutCode = SendOtpBase & {
+  code?: never;
+  hashCode?: never;
+};
+
+export type SendOtpType = SendOtpWithCode | SendOtpWithoutCode;
+
+export class OtpService {
+  async checkOtpRestrictions(email: string) {
+    const otpLock = await redis.get(`otp_lock:${email}`);
+    if (otpLock) {
+      throw ApiError.badRequest(
+        "Your Account is locked due to multiple failed attempts. Please try again after 30 minutes."
+      );
+    }
+
+    if (await redis.get(`otp_spam_lock:${email}`)) {
+      throw ApiError.tooManyRequests(
+        "Too many otp requests. Please try again after 1 hour before requesting again."
+      );
+    }
+
+    if (await redis.get(`otp_cooldown:${email}`)) {
+      throw ApiError.tooManyRequests(
+        "Too many otp requests. Please try again after 1 minute before requesting new otp."
+      );
+    }
+  }
+
+  async trackOtpRequests(email: string) {
+    try {
+      const otpRequestKey = `otp_request_count:${email}`;
+      let otpRequestsCount = parseInt((await redis.get(otpRequestKey)) || "0");
+      if (otpRequestsCount >= OTP_MAX_ATTEMPTS) {
+        await redis.set(`otp_spam_lock:${email}`, "locked", {
+          expiration: {
+            type: "EX",
+            value: 3600
+          }
+        });
+        throw ApiError.tooManyRequests(
+          "Too many otp requests. Please try again after 1 hour before requesting again."
+        );
+      }
+
+      await redis.set(otpRequestKey, otpRequestsCount + 1, {
+        expiration: {
+          type: "EX",
+          value: 3600
+        }
+      });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw ApiError.server("Failed to track otp requests!");
+    }
+  }
+
+  async sendOtp({
+    name,
+    email,
+    templateName,
+    code,
+    hashCode,
+    subject
+  }: SendOtpType) {
+    try {
+      const newOtp = generateOTP(OTP_CODE_LENGTH);
+      const otpKey = `otp:${email}`;
+      const otpCooldownKey = `otp_cooldown:${email}`;
+      const otpHash = hashCode ? hashCode : newOtp.hashCode;
+
+      logger.info(
+        { email, code: code || newOtp.code },
+        "OTP generated successfully"
+      );
+
+      await redis.set(otpKey, otpHash, {
+        expiration: {
+          type: "EX",
+          value: OTP_EXPIRES_IN / 1000
+        }
+      });
+
+      await redis.set(otpCooldownKey, OTP_COOL_DOWN, {
+        expiration: {
+          type: "EX",
+          value: OTP_COOL_DOWN
+        }
+      });
+
+      try {
+        await sendEmail({
+          email,
+          subject,
+          data: {
+            code: code ? code : newOtp.code,
+            name
+          },
+          templateName
+        });
+      } catch (error) {
+        await Promise.allSettled([
+          redis.del(otpKey),
+          redis.del(otpCooldownKey)
+        ]);
+        throw error;
+      }
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw ApiError.server("Failed to send otp!");
+    }
+  }
+
+  async verifyOtp(hashCode: string, email: string) {
+    const hashOtpCodeKey = await redis.get(`otp:${email}`);
+
+    if (!hashOtpCodeKey) {
+      throw ApiError.badRequest("Invalid or expired otp");
+    }
+
+    const failedAttemptsKey = `otp_attempts:${email}`;
+    if (hashOtpCodeKey !== hashCode) {
+      const failedAttempts = await redis.incr(failedAttemptsKey);
+
+      if (failedAttempts === 1) {
+        await redis.expire(
+          failedAttemptsKey,
+          Math.floor(OTP_EXPIRES_IN / 1000)
+        );
+      }
+
+      if (failedAttempts >= OTP_MAX_ATTEMPTS) {
+        await redis.set(`otp_lock:${email}`, "locked", {
+          EX: OTP_SPAM_LOCK_TIME
+        });
+        throw ApiError.tooManyRequests(
+          "Too many failed attempts. Please try again after 1 hour."
+        );
+      }
+      throw ApiError.badRequest(
+        `Incorrect OTP. ${OTP_MAX_ATTEMPTS - failedAttempts} attempts left.`
+      );
+    }
+
+    await redis.del([`otp:${email}`, failedAttemptsKey]);
+  }
+}
+
+export const otpService = new OtpService();

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/upload/upload.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/modules/upload/upload.service.ts
@@ -1,0 +1,52 @@
+import { DeleteApiResponse } from "cloudinary";
+import cloudinary from "@/shared/configs/cloudinary";
+
+export interface UploadOptions {
+  folder: string;
+  resource_type?: "image" | "video" | "raw" | "auto";
+}
+
+export interface CloudinaryUploadResult {
+  url: string;
+  public_id: string;
+  size: number;
+}
+
+export const uploadToCloudinary = (
+  buffer: Buffer,
+  options: UploadOptions
+): Promise<CloudinaryUploadResult> => {
+  return new Promise((resolve, reject) => {
+    const stream = cloudinary.uploader.upload_stream(
+      {
+        folder: options.folder || "uploads",
+        resource_type: options.resource_type || "auto"
+      },
+      (error, result) => {
+        if (error || !result) {
+          return reject(error);
+        }
+        resolve({
+          url: result.secure_url,
+          public_id: result.public_id,
+          size: result.bytes
+        });
+      }
+    );
+
+    stream.end(buffer);
+  });
+};
+
+export const deleteFileFromCloudinary = (
+  publicIds: string[]
+): Promise<DeleteApiResponse> => {
+  return new Promise((resolve, reject) => {
+    cloudinary.api.delete_resources(publicIds, (error, result) => {
+      if (error || !result) {
+        return reject(error);
+      }
+      resolve(result);
+    });
+  });
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/routes/index.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/routes/index.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import healthRoutes from "../modules/health/health.routes";
+import authRoutes from "../modules/auth/auth.routes";
+import oauthRoutes from "../modules/oauth/oauth.routes";
+
+const router = Router();
+
+router.use("/v1/health", healthRoutes);
+router.use("/v1/auth", authRoutes);
+router.use("/auth", oauthRoutes); //* Here versioning is not given because, in google and github callback routes, we are not using versioning. process.env.GOOGLE_REDIRECT_URI
+
+export default router;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/server.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/server.ts
@@ -1,0 +1,32 @@
+import app from "./app";
+import env from "./shared/configs/env";
+import redisClient from "./shared/configs/redis";
+import { logger } from "./shared/utils/logger";
+import { configureGracefulShutdown } from "./shared/utils/shutdown";
+
+const port = env.PORT || 9000;
+
+redisClient
+  .connect()
+  .then(() => {
+    logger.info("Redis Connection Success");
+    const server = app.listen(port, () => {
+      logger.info("Hybrid Auth API started successfully");
+      logger.info(`URL          : http://localhost:${port}`);
+      logger.info(`Environment  : ${env.NODE_ENV}`);
+      logger.info(
+        `Version      : ${process.env.npm_package_version ?? "unknown"}`
+      );
+      logger.info(`Started At   : ${new Date().toISOString()}`);
+
+      if (env.NODE_ENV !== "production") {
+        logger.info(`API Docs     : http://localhost:${port}/api/docs`);
+      }
+    });
+
+    configureGracefulShutdown(server);
+  })
+  .catch((error: Error) => {
+    logger.error(error, "Redis Connection Failed");
+    process.exit(1);
+  });

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/cloudinary.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/cloudinary.ts
@@ -1,0 +1,10 @@
+import { v2 as cloudinary } from "cloudinary";
+import env from "./env";
+
+cloudinary.config({
+  cloud_name: env.CLOUDINARY_CLOUD_NAME,
+  api_key: env.CLOUDINARY_API_KEY,
+  api_secret: env.CLOUDINARY_API_SECRET
+});
+
+export default cloudinary;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/db.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/db.ts
@@ -1,0 +1,8 @@
+import { drizzle } from "drizzle-orm/mysql2";
+import env from "./env";
+
+const db = drizzle(env.DATABASE_URL!, {
+  logger: env.NODE_ENV === "development"
+});
+
+export default db;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/env.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/env.ts
@@ -1,0 +1,61 @@
+/* eslint-disable no-console */
+import dotenv from "dotenv-flow";
+dotenv.config();
+import { z } from "zod";
+
+export const envSchema = z.object({
+  NODE_ENV: z
+    .enum(["development", "test", "production"])
+    .default("development"),
+
+  PORT: z.string().regex(/^\d+$/, "PORT must be a number").transform(Number),
+
+  DATABASE_URL: z.url(),
+
+  CORS_ORIGIN: z.string(),
+  CLIENT_URL: z.url(),
+
+  LOG_LEVEL: z
+    .enum(["fatal", "error", "warn", "info", "debug", "trace"])
+    .default("info"),
+
+  JWT_ACCESS_SECRET: z.string().min(32),
+  JWT_REFRESH_SECRET: z.string().min(32),
+
+  CRYPTO_SECRET: z.string().min(32),
+
+  RESEND_API_KEY: z.string(),
+  EMAIL_FROM: z.email(),
+
+  CLOUDINARY_CLOUD_NAME: z.string(),
+  CLOUDINARY_API_KEY: z.string(),
+  CLOUDINARY_API_SECRET: z.string(),
+
+  GOOGLE_CLIENT_ID: z.string(),
+  GOOGLE_CLIENT_SECRET: z.string(),
+  GOOGLE_REDIRECT_URI: z.url(),
+
+  GITHUB_CLIENT_ID: z.string(),
+  GITHUB_CLIENT_SECRET: z.string(),
+  GITHUB_REDIRECT_URI: z.url(),
+
+  FACEBOOK_APP_ID: z.string(),
+  FACEBOOK_APP_SECRET: z.string(),
+  FACEBOOK_REDIRECT_URI: z.url(),
+
+  REDIS_URL: z.url()
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+const result = envSchema.safeParse(process.env);
+
+if (!result.success) {
+  console.error("❌ Invalid environment configuration");
+  console.error(z.treeifyError(result.error));
+  process.exit(1);
+}
+
+export const env: Readonly<Env> = Object.freeze(result.data);
+
+export default env;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/passport.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/passport.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import passport from "passport";
+import {
+  Strategy as GitHubStrategy,
+  Profile as GithubProfile
+} from "passport-github2";
+
+import {
+  Strategy as GoogleStrategy,
+  Profile as GoogleProfile
+} from "passport-google-oauth20";
+
+import env from "./env";
+
+//? GITHUB STRATEGY
+passport.use(
+  new GitHubStrategy(
+    {
+      clientID: env.GITHUB_CLIENT_ID,
+      clientSecret: env.GITHUB_CLIENT_SECRET,
+      callbackURL: env.GITHUB_REDIRECT_URI
+    },
+    function (
+      accessToken: string,
+      refreshToken: string,
+      profile: GithubProfile,
+      cb: (error: Error | null, user?: any) => void
+    ) {
+      // console.log({ profile });
+      return cb(null, profile);
+    }
+  )
+);
+
+//? GOOGLE STRATEGY
+passport.use(
+  new GoogleStrategy(
+    {
+      clientID: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
+      callbackURL: env.GOOGLE_REDIRECT_URI
+    },
+    function (accessToken, refreshToken, profile: GoogleProfile, cb) {
+      return cb(null, profile);
+    }
+  )
+);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/redis.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/redis.ts
@@ -1,0 +1,8 @@
+import { createClient } from "redis";
+import { env } from "./env";
+
+const redisClient = createClient({
+  url: env.REDIS_URL
+});
+
+export default redisClient;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/resend.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/resend.ts
@@ -1,0 +1,4 @@
+import { Resend } from "resend";
+import env from "./env";
+
+export const resend = new Resend(env.RESEND_API_KEY);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/swagger.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/configs/swagger.ts
@@ -1,0 +1,11 @@
+import swaggerUi from "swagger-ui-express";
+import { Express } from "express";
+import env from "../configs/env";
+
+import swaggerDocument from "@/docs/swagger.json";
+
+export const setupSwagger = (app: Express) => {
+  if (env.NODE_ENV !== "development") return;
+
+  app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/constants/status-codes.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/constants/status-codes.ts
@@ -1,0 +1,30 @@
+export const STATUS_CODES = {
+  // 2xx Success
+  OK: 200,
+  CREATED: 201,
+  ACCEPTED: 202,
+  NO_CONTENT: 204,
+
+  // 3xx Redirection
+  MOVED_PERMANENTLY: 301,
+  FOUND: 302,
+  NOT_MODIFIED: 304,
+
+  // 4xx Client Errors
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  UNPROCESSABLE_ENTITY: 422,
+  TOO_MANY_REQUESTS: 429,
+
+  // 5xx Server Errors
+  INTERNAL_SERVER_ERROR: 500,
+  NOT_IMPLEMENTED: 501,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503,
+  GATEWAY_TIMEOUT: 504
+} as const;
+
+export type StatusCode = (typeof STATUS_CODES)[keyof typeof STATUS_CODES];

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/email-templates/delete-account.ejs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/email-templates/delete-account.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Delete Account Request</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      padding: 20px;
+      color: #333;
+    }
+    p {
+      margin-bottom: 10px;
+    }
+    a {
+      color: #007bff;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <p>Hello <%= name %>,</p>
+  <p>We received a request to delete your account. If you confirm this action, your account will be permanently deleted.</p>
+  <p>To confirm, please click the link below:</p>
+  <a href="<%= deleteAccountUrl %>">Confirm Delete Account</a>
+  <p>If you did not request this action, please ignore this email or reply to let us know. Your account is still secure.</p>
+  <p>Thank you,</p>
+</body>
+</html>

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/email-templates/email-verification.ejs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/email-templates/email-verification.ejs
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify your email</title>
+</head>
+
+<body
+  style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #f4f4f7; margin: 0; padding: 0; color: #51545e;">
+  <div style="background-color: #f4f4f7; padding: 40px 0;">
+    <div
+      style="margin: 0 auto; background-color: #ffffff; padding: 40px 20px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05); max-width: 600px;">
+
+      <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #333333; font-size: 24px; font-weight: 700; margin: 0;">Verify your email</h1>
+      </div>
+
+      <p style="font-size: 16px; line-height: 1.6; margin-bottom: 24px; color: #51545e;">Hello <strong>
+          <%= name %>
+        </strong>,</p>
+
+      <p style="font-size: 16px; line-height: 1.6; margin-bottom: 30px; color: #51545e;">
+        Thank you for registering. Please use the following One-Time Password (OTP) to verify your email address. This
+        code is valid for 5 minutes.
+      </p>
+
+      <div style="text-align: center; margin-bottom: 30px;">
+        <div
+          style="display: inline-block; padding: 16px 40px; background-color: #f8fafc; border-radius: 8px; border: 1px solid #e2e8f0;">
+          <span
+            style="font-family: 'Courier New', Courier, monospace; font-size: 32px; font-weight: 700; letter-spacing: 6px; color: #1e293b;">
+            <%= code %>
+          </span>
+        </div>
+      </div>
+
+      <p style="font-size: 14px; line-height: 1.6; color: #64748b; margin-top: 24px;">
+        If you didn't request this verification, you can safely ignore this email.
+      </p>
+
+      <div style="margin-top: 40px; padding-top: 24px; border-top: 1px solid #e2e8f0; text-align: center;">
+        <p style="font-size: 12px; color: #94a3b8; margin: 0;">
+          &copy; <%= new Date().getFullYear() %>. All rights reserved.
+        </p>
+      </div>
+
+    </div>
+  </div>
+</body>
+
+</html>

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/email-templates/forgot-password.ejs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/email-templates/forgot-password.ejs
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify your OTP</title>
+</head>
+
+<body
+  style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #f4f4f7; margin: 0; padding: 0; color: #51545e;">
+  <div style="background-color: #f4f4f7; padding: 40px 0;">
+    <div
+      style="margin: 0 auto; background-color: #ffffff; padding: 40px 20px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05); max-width: 600px;">
+
+      <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #333333; font-size: 24px; font-weight: 700; margin: 0;">
+          Forgot Password - Verify OTP
+        </h1>
+      </div>
+
+      <p style="font-size: 16px; line-height: 1.6; margin-bottom: 24px; color: #51545e;">Hello <strong>
+          <%= name %>
+        </strong>,</p>
+
+      <p style="font-size: 16px; line-height: 1.6; margin-bottom: 30px; color: #51545e;">
+        Thank you for using our service. Please use the following One-Time Password (OTP) to verify your password reset
+        request. This
+        code is valid for 5 minutes.
+      </p>
+
+      <div style="text-align: center; margin-bottom: 30px;">
+        <div
+          style="display: inline-block; padding: 16px 40px; background-color: #f8fafc; border-radius: 8px; border: 1px solid #e2e8f0;">
+          <span
+            style="font-family: 'Courier New', Courier, monospace; font-size: 32px; font-weight: 700; letter-spacing: 6px; color: #1e293b;">
+            <%= code %>
+          </span>
+        </div>
+      </div>
+
+      <p style="font-size: 14px; line-height: 1.6; color: #64748b; margin-top: 24px;">
+        If you didn't request this request, you can safely ignore this email.
+      </p>
+
+      <div style="margin-top: 40px; padding-top: 24px; border-top: 1px solid #e2e8f0; text-align: center;">
+        <p style="font-size: 12px; color: #94a3b8; margin: 0;">
+          &copy; <%= new Date().getFullYear() %>. All rights reserved.
+        </p>
+      </div>
+
+    </div>
+  </div>
+</body>
+
+</html>

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/helpers/cookie.helper.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/helpers/cookie.helper.ts
@@ -1,0 +1,75 @@
+import { Response } from "express";
+import {
+  ACCESS_TOKEN_EXPIRY,
+  REFRESH_TOKEN_EXPIRY,
+  SESSION_EXPIRY
+} from "@/modules/auth/auth.constants";
+import env from "../configs/env";
+
+const isProduction = env.NODE_ENV === "production";
+
+export const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: isProduction ? ("none" as const) : ("lax" as const),
+  path: "/"
+};
+
+export function setAuthCookies(
+  res: Response,
+  accessToken: string,
+  refreshToken: string,
+  sessionId: string
+) {
+  setCookies(res, [
+    {
+      cookie: "accessToken",
+      value: accessToken,
+      maxAge: ACCESS_TOKEN_EXPIRY
+    },
+    {
+      cookie: "refreshToken",
+      value: refreshToken,
+      maxAge: REFRESH_TOKEN_EXPIRY
+    },
+    {
+      cookie: "sid",
+      value: sessionId,
+      maxAge: SESSION_EXPIRY
+    }
+  ]);
+}
+
+export function clearAuthCookies(res: Response) {
+  clearCookie(res, "accessToken");
+  clearCookie(res, "refreshToken");
+  clearCookie(res, "sid");
+}
+
+export function clearCookie(
+  res: Response,
+  cookie: string = "sid",
+  path: string = "/"
+) {
+  res.clearCookie(cookie, {
+    ...COOKIE_OPTIONS,
+    path
+  });
+}
+
+type Cookie = {
+  cookie: string;
+  value: string;
+  maxAge: number;
+  path?: string;
+};
+
+export function setCookies(res: Response, cookies: Cookie[]) {
+  cookies.forEach(({ cookie, value, maxAge, path = "/" }) => {
+    res.cookie(cookie, value, {
+      ...COOKIE_OPTIONS,
+      path,
+      maxAge
+    });
+  });
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/helpers/token.helpers.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/helpers/token.helpers.ts
@@ -1,0 +1,50 @@
+import crypto from "node:crypto";
+
+export function generateOTP(length: number = 6, ttlMinutes: number = 5) {
+  const code = crypto
+    .randomInt(0, Math.pow(10, length))
+    .toString()
+    .padStart(length, "0");
+
+  const hashCode = crypto
+    .createHash("sha256")
+    .update(String(code))
+    .digest("hex");
+
+  const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString();
+
+  return { code, hashCode, expiresAt };
+}
+
+export function generateHashedToken(token: string): string {
+  return crypto.createHash("sha256").update(String(token)).digest("hex");
+}
+
+export function generateSecureToken(length: number = 32): string {
+  return crypto.randomBytes(length).toString("hex");
+}
+
+export function verifyHashedToken(token: string, hashedToken: string): boolean {
+  return (
+    crypto.createHash("sha256").update(String(token)).digest("hex") ===
+    hashedToken
+  );
+}
+
+export function generateTokenAndHashedToken(id: string) {
+  const cryptoSecret = process.env.CRYPTO_SECRET! || "secret";
+  const token = crypto
+    .createHmac("sha256", cryptoSecret)
+    .update(String(id))
+    .digest("hex");
+
+  const hashedToken = crypto
+    .createHash("sha256")
+    .update(String(token))
+    .digest("hex");
+  return { token, hashedToken };
+}
+
+export function generateUUID(): string {
+  return crypto.randomUUID();
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/error-handler.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/error-handler.ts
@@ -1,0 +1,40 @@
+import { Request, Response, NextFunction } from "express";
+import env from "../configs/env";
+
+import { logger } from "../utils/logger";
+import { ApiError } from "../utils/api-error";
+
+export const errorHandler = (
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (res.headersSent) {
+    return next(err);
+  }
+  let statusCode = 500;
+  let message = "Internal server error";
+  let errors: unknown;
+
+  if (err instanceof ApiError) {
+    statusCode = err.statusCode;
+    message = err.message;
+    errors = err.errors;
+  }
+
+  logger.error(
+    err,
+    `Error: ${message} | Status: ${statusCode} | Path: ${req.method} ${req.originalUrl}`
+  );
+
+  const response = {
+    success: false,
+    message,
+    statusCode,
+    ...(errors !== undefined && { errors }),
+    ...(env.NODE_ENV === "development" && { stack: err.stack })
+  };
+
+  res.status(statusCode).json(response);
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/not-found-handler.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/not-found-handler.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from "express";
+import { ApiError } from "../utils/api-error";
+
+export const notFoundHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  throw ApiError.notFound(`Route ${req.method} ${req.originalUrl} not found`);
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/rate-limiter.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/rate-limiter.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextFunction, Request, Response } from "express";
+import { rateLimit } from "express-rate-limit";
+import { STATUS_CODES } from "../constants/status-codes";
+import { ApiError } from "../utils/api-error";
+
+export const rateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per window
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  message: {
+    success: false,
+    message:
+      "Too many requests from this IP, please try again after 15 minutes",
+    status: 429
+  },
+  handler: (req: Request, res: Response, next: NextFunction, options: any) => {
+    next(new ApiError(STATUS_CODES.TOO_MANY_REQUESTS, options.message.message));
+  }
+});
+
+/**
+ * Stricter rate limiter for sensitive routes (e.g., auth, login)
+ */
+export const authRateLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 5, // Limit each IP to 5 failed attempts per hour
+  handler: (req, res, next, options) => {
+    next(
+      ApiError.tooManyRequests(
+        "Too many login attempts, please try again after an hour"
+      )
+    );
+  }
+});
+
+/**
+ * Rate limiter for login route
+ */
+export const signinRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many login attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+/**
+ * Rate limiter for registration route
+ */
+export const signupRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many registration attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const otpRequestLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  max: 6,
+  message: {
+    success: false,
+    message: "Too many OTP requests. Please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const otpVerificationLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  max: 6,
+  message: {
+    success: false,
+    message: "Too many OTP verification attempts. Please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const resetPasswordLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 6,
+  message: {
+    success: false,
+    message: "Too many password reset attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const deleteAccountLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many account deletion attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const changePasswordLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many password change attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/security-header.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/security-header.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Request, Response } from "express";
+import cors from "cors";
+import { Express } from "express";
+import helmet from "helmet";
+import env from "../configs/env";
+
+export const configureSecurityHeaders = (app: Express) => {
+  // Use Helmet to set various security-related HTTP headers
+  app.use(helmet());
+
+  // Configure CORS
+  app.use(
+    cors({
+      origin: env.CORS_ORIGIN || "*",
+      credentials: true,
+      methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"]
+    })
+  );
+
+  // Additional custom security headers
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("X-XSS-Protection", "1; mode=block");
+    next();
+  });
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/upload-file.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/upload-file.ts
@@ -1,0 +1,30 @@
+import multer from "multer";
+
+export const ALLOWED_FILE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "video/mp4",
+  "video/mpeg",
+  "video/quicktime",
+  "application/pdf"
+];
+
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+const storage = multer.memoryStorage();
+
+const fileFilter: multer.Options["fileFilter"] = (_req, file, cb) => {
+  if (!ALLOWED_FILE_TYPES.includes(file.mimetype)) {
+    return cb(null, false);
+  }
+  cb(null, true);
+};
+
+const upload = multer({
+  storage,
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter
+});
+
+export default upload;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/user-account-restriction.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/user-account-restriction.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextFunction, Response } from "express";
+import db from "../configs/db";
+import { users } from "@/db/schemas/user.schema";
+import { eq } from "drizzle-orm";
+import { ApiError } from "../utils/api-error";
+import { logger } from "../utils/logger";
+import { getRemainingTime } from "../utils/date";
+import { UserRequest } from "@/types/global";
+
+export async function checkUserAccountRestriction(
+  req: UserRequest,
+  _res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    if (!req.user?.id) {
+      return next(ApiError.unauthorized("Unauthorized"));
+    }
+
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, parseInt(req?.user?.id || "0")));
+
+    if (!user) {
+      return next(ApiError.unauthorized("Unauthorized, please login."));
+    }
+
+    if (user.isDeleted || user.deletedAt) {
+      return next(ApiError.forbidden("Your account has been deactivated."));
+    }
+
+    if (user.lockUntil && user.lockUntil.getTime() > Date.now()) {
+      const remainingTime = getRemainingTime(user.lockUntil);
+
+      return next(
+        ApiError.forbidden(
+          `Your account has been locked. Please try again after ${remainingTime.minutes} minutes and ${remainingTime.seconds} seconds.`
+        )
+      );
+    }
+
+    if (!user.isEmailVerified) {
+      return next(
+        ApiError.forbidden("Email not verified. Please verify your email.")
+      );
+    }
+
+    return next();
+  } catch (err: any) {
+    logger.error(err?.message || err);
+    return next(ApiError.server("Something went wrong"));
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/validate-id.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/validate-id.ts
@@ -1,0 +1,14 @@
+import { ApiError } from "../utils/api-error";
+import { NextFunction, Request, Response } from "express";
+
+export const validateObjectId = (paramName: string = "id") => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const value =
+      req?.params[paramName] || req?.body[paramName] || req?.query[paramName];
+    if (!value || typeof value !== "string" || value.trim().length === 0) {
+      throw ApiError.badRequest(`Invalid ${paramName}`);
+    }
+
+    next();
+  };
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/validate-request.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/validate-request.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from "express";
+import z, { ZodError, type ZodObject } from "zod";
+
+import { ApiError } from "../utils/api-error";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const validateRequest = (schema: ZodObject<any>) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      schema.parse(req.body);
+
+      next();
+    } catch (error) {
+      if (!(error instanceof ZodError)) {
+        return next(error);
+      }
+
+      return next(
+        ApiError.badRequest(
+          "Invalid request data",
+          z.flattenError(error).fieldErrors || z.flattenError(error)
+        )
+      );
+    }
+  };
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/verify-auth.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/middlewares/verify-auth.ts
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextFunction, Response } from "express";
+import { verifyAccessToken } from "@/shared/utils/jwt";
+import { ApiError } from "@/shared/utils/api-error";
+import redisClient from "@/shared/configs/redis";
+import { UserRequest } from "@/types/global";
+import { SessionData } from "@/modules/auth/auth.interfaces";
+
+export async function verifyAuthentication(
+  req: UserRequest,
+  _res: Response,
+  next: NextFunction
+): Promise<void> {
+  const authHeader = req.headers.authorization || "";
+  const token = authHeader.startsWith("Bearer ")
+    ? authHeader.split(" ")[1]
+    : null;
+
+  const accessToken = req.cookies?.accessToken || token;
+  if (!accessToken) {
+    return next(ApiError.unauthorized("Missing access token"));
+  }
+
+  try {
+    const decoded = verifyAccessToken(accessToken);
+
+    const sessionKey = `session:${decoded.sessionId}`;
+    const sessionData = await redisClient.get(sessionKey);
+    if (!sessionData) {
+      return next(ApiError.unauthorized("Session not found"));
+    }
+
+    let session: SessionData;
+
+    try {
+      session = JSON.parse(sessionData) as SessionData;
+    } catch {
+      return next(ApiError.unauthorized("Invalid session"));
+    }
+
+    if (session.ip !== req.ip) {
+      return next(ApiError.unauthorized("Suspicious session"));
+    }
+
+    if (session.userAgent !== req.headers["user-agent"]) {
+      return next(ApiError.unauthorized("Suspicious session"));
+    }
+
+    if (session.expiresAt < new Date()) {
+      return next(ApiError.unauthorized("Session expired"));
+    }
+
+    req.user = {
+      id: decoded._id,
+      role: decoded.role,
+      sessionId: decoded.sessionId
+    };
+    return next();
+  } catch (err: any) {
+    if (err.name === "TokenExpiredError") {
+      return next(ApiError.unauthorized("Access token expired"));
+    }
+    return next(ApiError.unauthorized("Invalid access token"));
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/api-error.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/api-error.ts
@@ -1,0 +1,60 @@
+import { STATUS_CODES, StatusCode } from "../constants/status-codes";
+
+export class ApiError extends Error {
+  public readonly statusCode: StatusCode;
+  public readonly isOperational: boolean;
+  public readonly errors?: unknown;
+
+  constructor(
+    statusCode: StatusCode,
+    message: string,
+    errors?: unknown,
+    isOperational = true
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+    this.errors = errors;
+    this.isOperational = isOperational;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+
+  static badRequest(message = "Bad Request", errors?: unknown) {
+    return new ApiError(STATUS_CODES.BAD_REQUEST, message, errors);
+  }
+
+  static unauthorized(message = "Unauthorized") {
+    return new ApiError(STATUS_CODES.UNAUTHORIZED, message);
+  }
+
+  static forbidden(message = "Forbidden") {
+    return new ApiError(STATUS_CODES.FORBIDDEN, message);
+  }
+
+  static notFound(message = "Not Found") {
+    return new ApiError(STATUS_CODES.NOT_FOUND, message);
+  }
+
+  static conflict(message = "Conflict") {
+    return new ApiError(STATUS_CODES.CONFLICT, message);
+  }
+
+  static server(message = "Internal Server Error") {
+    return new ApiError(STATUS_CODES.INTERNAL_SERVER_ERROR, message);
+  }
+
+  static unprocessableEntity(message = "Unprocessable Entity") {
+    return new ApiError(STATUS_CODES.UNPROCESSABLE_ENTITY, message);
+  }
+
+  static tooManyRequests(message = "Too Many Requests") {
+    return new ApiError(STATUS_CODES.TOO_MANY_REQUESTS, message);
+  }
+}
+
+/*
+  ? Usage:
+  * throw new ApiError(404, "Not found");
+  * throw ApiError.badRequest("Bad request");
+ */

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/api-response.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/api-response.ts
@@ -1,0 +1,70 @@
+import { STATUS_CODES, StatusCode } from "../constants/status-codes";
+import type { Response } from "express";
+
+type ApiResponseParams<T> = {
+  success: boolean;
+  message: string;
+  statusCode: StatusCode;
+  data?: T | null;
+  errors?: unknown;
+};
+
+export class ApiResponse<T = unknown> {
+  public readonly success: boolean;
+  public readonly message: string;
+  public readonly statusCode: StatusCode;
+  public readonly data?: T | null;
+  public readonly errors?: unknown;
+
+  constructor({
+    success,
+    message,
+    statusCode,
+    data,
+    errors
+  }: ApiResponseParams<T>) {
+    this.success = success;
+    this.message = message;
+    this.statusCode = statusCode;
+    this.data = data;
+    this.errors = errors;
+  }
+
+  send(res: Response): Response {
+    return res.status(this.statusCode).json({
+      success: this.success,
+      message: this.message,
+      statusCode: this.statusCode,
+      ...(this.data !== undefined && { data: this.data }),
+      ...(this.errors !== undefined && { errors: this.errors })
+    });
+  }
+
+  static Success<T>(
+    res: Response,
+    message: string,
+    data?: T,
+    statusCode: StatusCode = STATUS_CODES.OK
+  ): Response {
+    return new ApiResponse<T>({
+      success: true,
+      message,
+      data,
+      statusCode
+    }).send(res);
+  }
+
+  static ok<T>(res: Response, message = "OK", data?: T) {
+    return ApiResponse.Success(res, message, data, STATUS_CODES.OK);
+  }
+
+  static created<T>(res: Response, message = "Created", data?: T) {
+    return ApiResponse.Success(res, message, data, STATUS_CODES.CREATED);
+  }
+}
+
+/*
+ * Usage:
+ * ApiResponse.ok(res, "OK", data);
+ * ApiResponse.created(res, "Created", data);
+ */

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/async-handler.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/async-handler.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from "express";
+
+export type AsyncRouteHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => Promise<unknown>;
+
+export function AsyncHandler(fn: AsyncRouteHandler) {
+  return function (req: Request, res: Response, next: NextFunction) {
+    Promise.resolve()
+      .then(() => fn(req, res, next))
+      .catch(next);
+  };
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/date.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/date.ts
@@ -1,0 +1,22 @@
+export function getRemainingTime(date: Date) {
+  const now = new Date();
+  let diff = date.getTime() - now.getTime();
+
+  if (diff <= 0) {
+    return {
+      days: 0,
+      minutes: 0,
+      seconds: 0
+    };
+  }
+
+  const seconds = Math.floor((diff / 1000) % 60);
+  const minutes = Math.floor((diff / (1000 * 60)) % 60);
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  return {
+    days,
+    minutes,
+    seconds
+  };
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/jwt.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/jwt.ts
@@ -1,0 +1,44 @@
+import jwt from "jsonwebtoken";
+import env from "../configs/env";
+
+const JWT_ACCESS_TOKEN_EXPIRY = "15m";
+const JWT_REFRESH_TOKEN_EXPIRY = "7d";
+
+export function generateAccessToken(user: {
+  _id: string;
+  role: "user" | "admin";
+  sessionId: string;
+}) {
+  return jwt.sign(
+    { _id: user._id, role: user.role, sessionId: user.sessionId },
+    env.JWT_ACCESS_SECRET!,
+    {
+      expiresIn: JWT_ACCESS_TOKEN_EXPIRY
+    }
+  );
+}
+
+export function generateRefreshToken(user: { _id: string; sessionId: string }) {
+  return jwt.sign(
+    { _id: user._id, sessionId: user.sessionId },
+    env.JWT_REFRESH_SECRET!,
+    {
+      expiresIn: JWT_REFRESH_TOKEN_EXPIRY
+    }
+  );
+}
+
+export function verifyAccessToken(token: string) {
+  return jwt.verify(token, env.JWT_ACCESS_SECRET!) as {
+    _id: string;
+    role: "user" | "admin";
+    sessionId: string;
+  };
+}
+
+export function verifyRefreshToken(token: string) {
+  return jwt.verify(token, env.JWT_REFRESH_SECRET!) as {
+    _id: string;
+    sessionId: string;
+  };
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/logger.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/logger.ts
@@ -1,0 +1,17 @@
+import pino from "pino";
+import env from "../configs/env";
+
+export const logger = pino({
+  level: env.LOG_LEVEL,
+  transport:
+    env.NODE_ENV !== "production"
+      ? {
+          target: "pino-pretty",
+          options: {
+            colorize: true,
+            translateTime: "yyyy-mm-dd HH:MM:ss",
+            ignore: "pid,hostname"
+          }
+        }
+      : undefined
+});

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/render-email-template.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/render-email-template.ts
@@ -1,0 +1,16 @@
+import ejs from "ejs";
+import path from "node:path";
+
+export async function renderEmailTemplates(
+  templateName: string,
+  data: Record<string, unknown>
+) {
+  const templatePath = path.join(
+    process.cwd(),
+    "src",
+    "shared",
+    "email-templates",
+    `${templateName}.ejs`
+  );
+  return ejs.renderFile(templatePath, data);
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/send-mail.ts
@@ -1,0 +1,32 @@
+import env from "../configs/env";
+import { resend } from "../configs/resend";
+import { renderEmailTemplates } from "./render-email-template";
+
+export type SendMailType = {
+  from?: string;
+  subject: string;
+  data: Record<string, unknown>;
+  email: string;
+  html?: string;
+  templateName: string;
+};
+
+export async function sendEmail({
+  from,
+  email,
+  subject,
+  data,
+  html,
+  templateName
+}: SendMailType) {
+  const htmlContent =
+    (await renderEmailTemplates(templateName, data)) || html || "";
+
+  return await resend.emails.send({
+    from: from || env.EMAIL_FROM,
+    to: email,
+    subject,
+    replyTo: email,
+    html: htmlContent
+  });
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/shutdown.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/shutdown.ts
@@ -1,0 +1,30 @@
+import { Server } from "http";
+import { logger } from "./logger";
+
+export const configureGracefulShutdown = (server: Server) => {
+  const signals = ["SIGTERM", "SIGINT"];
+
+  signals.forEach(signal => {
+    process.on(signal, () => {
+      logger.info(`\n${signal} signal received. Shutting down gracefully...`);
+
+      server.close(err => {
+        if (err) {
+          logger.error(err, "Error during server close");
+          process.exit(1);
+        }
+
+        logger.info("HTTP server closed.");
+        process.exit(0);
+      });
+
+      // Force shutdown after 10 seconds
+      setTimeout(() => {
+        logger.error(
+          "Could not close connections in time, forcefully shutting down"
+        );
+        process.exit(1);
+      }, 10000);
+    });
+  });
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/types/global.d.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/types/global.d.ts
@@ -1,0 +1,9 @@
+import { Request } from "express";
+
+export interface UserRequest extends Request {
+  user?: {
+    id?: string | undefined;
+    role?: "user" | "admin" | undefined;
+    sessionId?: string | undefined;
+  };
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/swagger.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/swagger.config.ts
@@ -1,0 +1,16 @@
+import swaggerAutoGen from "swagger-autogen";
+
+const doc = {
+  info: {
+    title: "Hybrid Auth API",
+    description: "Hybrid Auth API",
+    version: "1.0.0"
+  },
+  host: "localhost:9000/api",
+  schemes: ["http"]
+};
+
+const outputFile = "./src/docs/swagger.json";
+const endpointsFiles = ["./src/routes/*.ts"];
+
+swaggerAutoGen(outputFile, endpointsFiles, doc);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/tsconfig.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": [ "./src/*" ]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": [ "src/**/*" ],
+  "exclude": [ "node_modules" ]
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/.gitignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/.husky/pre-commit
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/.prettierignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/.prettierrc
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/README.md
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/README.md
@@ -1,0 +1,49 @@
+# Hybrid Auth MYSQL MVC
+
+Minimal Node.js + Express + TypeScript MVC starter using MYSQL, Drizzle ORM, and hybrid authentication (local and OAuth via Passport or similar).
+
+## Features
+
+- Express + TypeScript MVC structure
+- MYSQL + Drizzle integration
+- Hybrid auth: local credentials and OAuth providers (e.g., Google, GitHub)
+- Session-based authentication compatible with production
+- Environment-driven configuration with `.env`
+- Dev and production scripts
+
+## What This Provides
+
+- A clean starting point for credential and OAuth login
+- Prewired Express app with routing and session middleware
+- MYSQL connection wiring ready for your schema and data models
+- TypeScript configuration and scripts for iterative dev and production builds
+- Example environment keys you can enable as needed
+
+## Quick Start
+
+1. Install dependencies:
+   - `npm install`
+2. Configure environment:
+   - Create `.env` (copy from `.env.example` if present).
+   - Set variables shown below.
+3. Run in development:
+   - `npm run dev`
+4. Build and run in production:
+   - `npm run build`
+   - `npm start`
+
+## Requirements
+
+- Node.js 18+
+- MYSQL
+
+## Scripts
+
+- `npm run dev` — start development server
+- `npm run build` — compile TypeScript
+- `npm start` — start compiled app
+
+## Notes
+
+- Never commit `.env` or secrets.
+- Run your Drizzle migrations before starting the app.

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/drizzle.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/drizzle.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "drizzle-kit";
+import { env } from "./src/configs/env";
+
+export default defineConfig({
+  out: "./migrations",
+  schema: "./src/db/index.ts",
+  dialect: "mysql",
+  dbCredentials: {
+    url: env.DATABASE_URL
+  },
+  verbose: true,
+  strict: true
+});

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/package.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "servercn-hybrid-auth",
+  "version": "1.0.0",
+  "main": "dist/server.js",
+  "type": "module",
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development npx tsx watch --clearScreen=false src/server.ts",
+    "build": "rm -rf dist && tsc && tsc-alias",
+    "start": "cross-env NODE_ENV=production node dist/server.js",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio",
+    "typecheck": "tsc --noEmit",
+    "docs": "npx tsx swagger.config.ts",
+    "prepare": "husky",
+    "lint:check": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format:check": "npx prettier . --check",
+    "format:fix": "npx prettier . --write"
+  },
+  "lint-staged": {
+    "src/**/*.ts": [
+      "eslint --fix",
+      "prettier --write",
+      "tsc --noEmit"
+    ]
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/app.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/app.ts
@@ -1,0 +1,42 @@
+import express, { Express, Request, Response } from "express";
+import cookieParser from "cookie-parser";
+import morgan from "morgan";
+import { notFoundHandler } from "./middlewares/not-found-handler";
+import { errorHandler } from "./middlewares/error-handler";
+import env from "./configs/env";
+import { configureSecurityHeaders } from "./middlewares/security-header";
+
+import Routes from "./routes/index";
+
+import "./configs/passport";
+import sourceMapSupport from "source-map-support";
+import { setupSwagger } from "./configs/swagger";
+sourceMapSupport.install();
+
+const app: Express = express();
+
+//? Apply security headers before other middlewares and routes
+configureSecurityHeaders(app);
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+app.use(cookieParser());
+app.use(morgan(env.NODE_ENV === "development" ? "dev" : "combined"));
+
+//? Swagger Setup
+setupSwagger(app);
+
+//? Routes
+app.get("/", (req: Request, res: Response) => {
+  res.redirect("/api/v1/health");
+});
+
+app.use("/api", Routes);
+
+//? Not-found-handler (should be after routes)
+app.use(notFoundHandler);
+
+//? Global error handler (should be last)
+app.use(errorHandler);
+
+export default app;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/cloudinary.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/cloudinary.ts
@@ -1,0 +1,10 @@
+import { v2 as cloudinary } from "cloudinary";
+import env from "./env";
+
+cloudinary.config({
+  cloud_name: env.CLOUDINARY_CLOUD_NAME,
+  api_key: env.CLOUDINARY_API_KEY,
+  api_secret: env.CLOUDINARY_API_SECRET
+});
+
+export default cloudinary;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/db.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/db.ts
@@ -1,0 +1,8 @@
+import { drizzle } from "drizzle-orm/mysql2";
+import env from "./env";
+
+const db = drizzle(env.DATABASE_URL!, {
+  logger: env.NODE_ENV === "development"
+});
+
+export default db;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/env.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/env.ts
@@ -1,0 +1,57 @@
+/* eslint-disable no-console */
+import dotenv from "dotenv-flow";
+dotenv.config();
+import { z } from "zod";
+
+export const envSchema = z.object({
+  NODE_ENV: z
+    .enum(["development", "test", "production"])
+    .default("development"),
+
+  PORT: z.string().regex(/^\d+$/, "PORT must be a number").transform(Number),
+
+  DATABASE_URL: z.url(),
+
+  CORS_ORIGIN: z.string(),
+  CLIENT_URL: z.url(),
+
+  LOG_LEVEL: z
+    .enum(["fatal", "error", "warn", "info", "debug", "trace"])
+    .default("info"),
+
+  JWT_ACCESS_SECRET: z.string().min(32),
+  JWT_REFRESH_SECRET: z.string().min(32),
+
+  CRYPTO_SECRET: z.string().min(32),
+
+  RESEND_API_KEY: z.string(),
+  EMAIL_FROM: z.email(),
+
+  CLOUDINARY_CLOUD_NAME: z.string(),
+  CLOUDINARY_API_KEY: z.string(),
+  CLOUDINARY_API_SECRET: z.string(),
+
+  GOOGLE_CLIENT_ID: z.string(),
+  GOOGLE_CLIENT_SECRET: z.string(),
+  GOOGLE_REDIRECT_URI: z.url(),
+
+  GITHUB_CLIENT_ID: z.string(),
+  GITHUB_CLIENT_SECRET: z.string(),
+  GITHUB_REDIRECT_URI: z.url(),
+
+  REDIS_URL: z.url()
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+const result = envSchema.safeParse(process.env);
+
+if (!result.success) {
+  console.error("❌ Invalid environment configuration");
+  console.error(z.treeifyError(result.error));
+  process.exit(1);
+}
+
+export const env: Readonly<Env> = Object.freeze(result.data);
+
+export default env;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/passport.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/passport.ts
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import passport from "passport";
+import {
+  Strategy as GitHubStrategy,
+  Profile as GithubProfile
+} from "passport-github2";
+
+import {
+  Strategy as GoogleStrategy,
+  Profile as GoogleProfile
+} from "passport-google-oauth20";
+
+import env from "./env";
+
+//? GITHUB STRATEGY
+passport.use(
+  new GitHubStrategy(
+    {
+      clientID: env.GITHUB_CLIENT_ID,
+      clientSecret: env.GITHUB_CLIENT_SECRET,
+      callbackURL: env.GITHUB_REDIRECT_URI
+    },
+    function (
+      accessToken: string,
+      refreshToken: string,
+      profile: GithubProfile,
+      cb: (error: Error | null, user?: any) => void
+    ) {
+      // console.log({ profile });
+      return cb(null, profile);
+    }
+  )
+);
+
+//? GOOGLE STRATEGY
+passport.use(
+  new GoogleStrategy(
+    {
+      clientID: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
+      callbackURL: env.GOOGLE_REDIRECT_URI
+    },
+    function (accessToken, refreshToken, profile: GoogleProfile, cb) {
+      return cb(null, profile);
+    }
+  )
+);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/redis.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/redis.ts
@@ -1,0 +1,8 @@
+import { createClient } from "redis";
+import { env } from "./env";
+
+const redisClient = createClient({
+  url: env.REDIS_URL
+});
+
+export default redisClient;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/resend.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/resend.ts
@@ -1,0 +1,4 @@
+import { Resend } from "resend";
+import env from "./env";
+
+export const resend = new Resend(env.RESEND_API_KEY);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/swagger.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/configs/swagger.ts
@@ -1,0 +1,11 @@
+import swaggerUi from "swagger-ui-express";
+import { Express } from "express";
+import env from "../configs/env";
+
+import swaggerDocument from "../docs/swagger.json";
+
+export const setupSwagger = (app: Express) => {
+  if (env.NODE_ENV !== "development") return;
+
+  app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/constants/auth.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/constants/auth.ts
@@ -1,0 +1,34 @@
+export const OTP_MAX_ATTEMPTS = 5;
+
+export const OTP_TYPES = [
+  "signin",
+  "email-verification",
+  "password-reset",
+  "password-change"
+] as const;
+
+export const NEXT_OTP_DELAY = 1 * 60 * 1000; // 1 minute
+
+export const LOGIN_MAX_ATTEMPTS = 5 as const;
+
+export const OTP_CODE_LENGTH = 6 as const;
+
+export const OTP_COOL_DOWN = 60;
+
+export const OTP_EXPIRES_IN = 5 * 60 * 1000; // 5 minutes
+
+export const OTP_SPAM_LOCK_TIME = 3600; // 1 hour
+
+export const LOCK_TIME_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export const ACCESS_TOKEN_EXPIRY = 15 * 60 * 1000; // 15 minutes
+
+export const REFRESH_TOKEN_EXPIRY = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export const SESSION_EXPIRY = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export const RESET_PASSWORD_TOKEN_EXPIRY = 5 * 60 * 1000; // 5 minutes
+
+export const REACTIVATION_AVAILABLE_AT = 24 * 60 * 60 * 1000; // 24 hours
+
+export const DELETE_ACCOUNT_TOKEN_EXPIRY = 5 * 60 * 1000; // 5 minutes

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/constants/status-codes.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/constants/status-codes.ts
@@ -1,0 +1,30 @@
+export const STATUS_CODES = {
+  // 2xx Success
+  OK: 200,
+  CREATED: 201,
+  ACCEPTED: 202,
+  NO_CONTENT: 204,
+
+  // 3xx Redirection
+  MOVED_PERMANENTLY: 301,
+  FOUND: 302,
+  NOT_MODIFIED: 304,
+
+  // 4xx Client Errors
+  BAD_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  CONFLICT: 409,
+  UNPROCESSABLE_ENTITY: 422,
+  TOO_MANY_REQUESTS: 429,
+
+  // 5xx Server Errors
+  INTERNAL_SERVER_ERROR: 500,
+  NOT_IMPLEMENTED: 501,
+  BAD_GATEWAY: 502,
+  SERVICE_UNAVAILABLE: 503,
+  GATEWAY_TIMEOUT: 504
+} as const;
+
+export type StatusCode = (typeof STATUS_CODES)[keyof typeof STATUS_CODES];

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/controllers/auth.controller.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/controllers/auth.controller.ts
@@ -1,0 +1,459 @@
+import { NextFunction, Request, Response } from "express";
+import { ApiResponse } from "../utils/api-response";
+import { AsyncHandler } from "../utils/async-handler";
+
+import { ApiError } from "../utils/api-error";
+import { AuthService } from "../services/auth.service";
+import { clearAuthCookies, setAuthCookies } from "../helpers/cookie.helper";
+import { AvatarData, UserRequest } from "../types/user";
+import {
+  deleteFileFromCloudinary,
+  uploadToCloudinary
+} from "../services/cloudinary.service";
+import { DeleteAccountType, VerifyOtpType } from "../validators/auth";
+import db from "../configs/db";
+import { users } from "../db/schemas/user.schema";
+import { eq } from "drizzle-orm";
+
+//? SIGNUP USER
+export const signupUser = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { name, email, password, role } = req.body;
+    if (!name || !email || !password) {
+      return next(ApiError.badRequest("Name, email and password are required"));
+    }
+
+    await AuthService.registerUser({
+      name,
+      email,
+      password,
+      role
+    });
+
+    return ApiResponse.created(
+      res,
+      "User registered successfully. Please check your email for verification."
+    );
+  }
+);
+
+//? VERIFY USER
+export const verifyUser = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email, otpCode }: VerifyOtpType = req.body;
+
+    if (!email || !otpCode) {
+      return next(ApiError.badRequest("Email and code are required"));
+    }
+
+    await AuthService.verifyUser({ email, otpCode });
+
+    return ApiResponse.ok(res, "User verified successfully");
+  }
+);
+
+//? SIGNIN USER
+export const signinUser = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return next(ApiError.badRequest("Email and password are required"));
+    }
+
+    const ip = req.ip || "Unknown";
+    const userAgent = req.headers["user-agent"] || "Unknown";
+
+    await AuthService.signinUser(
+      { email, password, ip, userAgent },
+      {
+        setAuthCookie: (
+          accessToken: string,
+          refreshToken: string,
+          sessionId: string
+        ) => {
+          setAuthCookies(res, accessToken, refreshToken, sessionId);
+        }
+      }
+    );
+
+    return ApiResponse.ok(res, "User signed in successfully!");
+  }
+);
+
+//? GET USER PROFILE
+export const getUserProfile = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const currentSessionId = req.user?.sessionId;
+
+    if (!userId || !currentSessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const user = await AuthService.getUserProfile(userId.toString());
+    if (!user) {
+      return next(ApiError.notFound("User not found"));
+    }
+
+    if (user.isDeleted) {
+      return next(ApiError.notFound("This account has been deactivated."));
+    }
+
+    const result = await AuthService.getUserSessions(
+      userId.toString(),
+      currentSessionId
+    );
+
+    if (!result) {
+      return next(ApiError.server("Failed to get user sessions!"));
+    }
+
+    return ApiResponse.ok(res, "User profile fetched successfully", {
+      user: {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        avatar: user.avatar,
+        isEmailVerified: user.isEmailVerified,
+        lastLoginAt: user.lastLoginAt,
+        sessions: result
+      }
+    });
+  }
+);
+
+//? UPDATE PROFILE
+export const updateProfile = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const data = req.body;
+    const { name } = data;
+
+    if (!req.user?.id) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const user = await AuthService.getUserProfile(req.user?.id.toString());
+
+    if (!user) {
+      return next(ApiError.notFound("User not found"));
+    }
+
+    const avatar = user.avatar as AvatarData | null;
+    let updatedAvatar: AvatarData | null = avatar;
+
+    if (req?.file) {
+      const file = await uploadToCloudinary(req.file.buffer, {
+        folder: "uploads/files",
+        resource_type: "auto"
+      });
+      updatedAvatar = {
+        public_id: file.public_id,
+        url: file.url,
+        size: file.size
+      };
+    }
+
+    const updateData: Record<string, unknown> = {};
+    if (name) updateData.name = name;
+    if (updatedAvatar !== avatar) updateData.avatar = updatedAvatar;
+
+    if (Object.keys(updateData).length > 0) {
+      await db.update(users).set(updateData).where(eq(users.id, user.id));
+    }
+
+    if (avatar?.public_id && avatar.public_id !== updatedAvatar?.public_id) {
+      await deleteFileFromCloudinary([avatar.public_id]);
+    }
+
+    const updatedUser = await AuthService.getUserProfile(user.id.toString());
+
+    return ApiResponse.Success(res, "Profile updated successfully!", {
+      user: {
+        id: updatedUser?.id,
+        name: updatedUser?.name,
+        email: updatedUser?.email,
+        role: updatedUser?.role,
+        avatar: updatedUser?.avatar,
+        isEmailVerified: updatedUser?.isEmailVerified,
+        lastLoginAt: updatedUser?.lastLoginAt
+      }
+    });
+  }
+);
+
+//? REFRESH TOKENS
+export const refreshToken = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const accessToken = req.cookies?.accessToken;
+    const refreshToken = req.cookies?.refreshToken;
+
+    const token = await AuthService.refreshTokens(accessToken, refreshToken);
+
+    if (!token) {
+      return next(ApiError.server("Failed to refresh tokens!"));
+    }
+
+    const newAccessToken = token.accessToken;
+    const newRefreshToken = token.refreshToken;
+    setAuthCookies(res, newAccessToken, newRefreshToken, token.sessionId);
+
+    return ApiResponse.Success(res, "Tokens refreshed successfully!");
+  }
+);
+
+//? LOGOUT
+export const logoutUser = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req.user?.id;
+    if (!userId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const currentSessionId = req.user?.sessionId;
+    if (!currentSessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    await AuthService.logoutUser(userId.toString(), currentSessionId);
+
+    clearAuthCookies(res);
+
+    return ApiResponse.Success(res, "Logged out successfully!");
+  }
+);
+
+//? FORGOT PASSWORD
+export const forgotPassword = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { email } = req.body;
+    if (!email) {
+      return next(ApiError.badRequest("Email is required!"));
+    }
+
+    await AuthService.forgotPassword(email);
+
+    return ApiResponse.ok(
+      res,
+      "If an account exists, a reset code has been sent to your email."
+    );
+  }
+);
+
+//? VERIFY RESET PASSWORD TOKEN
+export const verifyResetPasswordOtp = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const { otpCode, email } = req.body;
+    if (!otpCode || !email) {
+      return next(ApiError.badRequest("OtpCode and email are required!"));
+    }
+
+    await AuthService.verifyResetPasswordOtp(otpCode, email);
+
+    return ApiResponse.ok(
+      res,
+      "Password reset otp verified successfully. You can now reset your password."
+    );
+  }
+);
+
+//? RESET PASSWORD
+export const resetPassword = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const { newPassword, email } = req.body;
+    if (!email || !newPassword) {
+      return next(ApiError.badRequest("Newpassword and email are required!"));
+    }
+
+    const result = await AuthService.resetPassword(next, email, newPassword);
+
+    if (!result) {
+      return next(ApiError.server("Failed to reset password!"));
+    }
+
+    clearAuthCookies(res);
+
+    return ApiResponse.ok(
+      res,
+      result.message || "Password reset successfully!"
+    );
+  }
+);
+
+//? CHANGE PASSWORD
+export const changePassword = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+
+    if (!userId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const { oldPassword, newPassword } = req.body;
+
+    if (!oldPassword || !newPassword) {
+      return next(
+        ApiError.badRequest("Old password and new password are required")
+      );
+    }
+
+    const result = await AuthService.changePassword(next, {
+      userId: userId.toString(),
+      oldPassword,
+      newPassword
+    });
+
+    if (!result) {
+      return next(ApiError.server("Failed to change password!"));
+    }
+
+    clearAuthCookies(res);
+
+    return ApiResponse.ok(
+      res,
+      result.message || "Password changed successfully!"
+    );
+  }
+);
+
+//? REQUEST DELETE ACCOUNT
+export const requestDeleteAccount = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const { password } = req.body;
+
+    if (!userId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    if (!password) {
+      return next(ApiError.badRequest("Password is required!"));
+    }
+
+    await AuthService.requestDeleteAccount(userId, password);
+
+    return ApiResponse.ok(
+      res,
+      "Account deletion request sent successfully. Please check your email to confirm."
+    );
+  }
+);
+
+//? DELETE/DEACTIVATE ACCOUNT
+export const deleteAccount = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const { userId, type }: DeleteAccountType = req.body;
+
+    if (!userId || !type) {
+      return next(ApiError.badRequest("User id and type are required!"));
+    }
+
+    const reqUserId = req?.user?.id;
+
+    if (!reqUserId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+    const token = req.query.token as string;
+    if (!token) {
+      return next(
+        ApiError.badRequest(
+          `${type === "hard" ? "Delete" : "Deactivate"} account token is required!`
+        )
+      );
+    }
+
+    if (userId !== reqUserId.toString()) {
+      return next(
+        ApiError.unauthorized("You are not authorized to perform this action")
+      );
+    }
+
+    await AuthService.deleteOrDeactiveAccount({ userId, type, token });
+
+    clearAuthCookies(res);
+
+    return ApiResponse.Success(
+      res,
+      `Account ${type === "soft" ? "deactivated" : "deleted"} successfully!`
+    );
+  }
+);
+
+//? REACTIVATE ACCOUNT
+export const reactivateAccount = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+
+    if (!userId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    await AuthService.reactivateAccount(userId);
+
+    return ApiResponse.Success(res, "Account reactivated successfully!");
+  }
+);
+
+//? GET USER SESSIONS
+export const getUserSessions = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const currentSessionId = req.user?.sessionId;
+
+    if (!userId || !currentSessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    const result = await AuthService.getUserSessions(
+      userId.toString(),
+      currentSessionId
+    );
+
+    if (!result) {
+      return next(ApiError.server("Failed to get user sessions!"));
+    }
+
+    return ApiResponse.ok(res, "User sessions fetched successfully", result);
+  }
+);
+
+//? DELETE SESSION
+export const deleteUserSession = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const { sessionId } = req.params;
+
+    if (!userId || !sessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    await AuthService.deleteSession(userId, sessionId as string);
+
+    const reqSId = req.cookies?.sid;
+
+    const isCurrentSession = sessionId === reqSId;
+    if (isCurrentSession) {
+      clearAuthCookies(res);
+    }
+
+    return ApiResponse.Success(res, "User session deleted successfully!");
+  }
+);
+
+//? DELETE ALL SESSIONS
+export const deleteAllUserSessions = AsyncHandler(
+  async (req: UserRequest, res: Response, next: NextFunction) => {
+    const userId = req?.user?.id;
+    const currentSessionId = req.user?.sessionId;
+
+    if (!userId || !currentSessionId) {
+      return next(ApiError.unauthorized("Unauthorized access"));
+    }
+
+    await AuthService.deleteAllUserSessions(userId);
+
+    clearAuthCookies(res);
+
+    return ApiResponse.Success(res, "User sessions deleted successfully!");
+  }
+);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/controllers/health.controller.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/controllers/health.controller.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from "express";
+import { ApiResponse } from "../utils/api-response";
+import { AsyncHandler } from "../utils/async-handler";
+
+export const healthCheck = AsyncHandler(
+  async (_req: Request, res: Response) => {
+    const healthData = {
+      status: "healthy",
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      environment: process.env.NODE_ENV || "development",
+      version: process.env.npm_package_version || "1.0.0",
+      memory: {
+        used:
+          Math.round((process.memoryUsage().heapUsed / 1024 / 1024) * 100) /
+          100,
+        total:
+          Math.round((process.memoryUsage().heapTotal / 1024 / 1024) * 100) /
+          100,
+        unit: "MB"
+      },
+      cpu: {
+        usage: process.cpuUsage()
+      }
+    };
+    return ApiResponse.Success(res, "Service is healthy", healthData);
+  }
+);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/controllers/oauth.controller.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/controllers/oauth.controller.ts
@@ -1,0 +1,102 @@
+import { NextFunction, Request, Response } from "express";
+import { Profile as GithubProfile } from "passport-github2";
+import { Profile as GoogleProfile } from "passport-google-oauth20";
+
+import { ApiResponse } from "../utils/api-response";
+import { AsyncHandler } from "../utils/async-handler";
+import { ApiError } from "../utils/api-error";
+import { OAuthService } from "../services/oauth.service";
+import { setAuthCookies } from "../helpers/cookie.helper";
+
+//? LOGIN WITH GITHUB
+export const githubOAuth = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const data = req.user as GithubProfile | undefined;
+
+    if (!data) {
+      return next(ApiError.unauthorized("Authenticated failed!"));
+    }
+
+    const user = {
+      provider: data?.provider as "local" | "google" | "github",
+      providerId: data.id,
+      name: data.displayName,
+      email: data?.emails && data?.emails[0]?.value,
+      isEmailVerified: true,
+      avatar: data.photos && data.photos[0].value,
+      ip: req.ip || "Unknown",
+      userAgent: req.get("user-agent") || req.headers["user-agent"] || "Unknown"
+    };
+
+    const existingUser = await OAuthService.handleOAuthLogin(user, {
+      setAuthCookie: (
+        accessToken: string,
+        refreshToken: string,
+        sessionId: string
+      ) => {
+        setAuthCookies(res, accessToken, refreshToken, sessionId);
+      }
+    });
+
+    //? save the data into your databases
+
+    ApiResponse.ok(res, "Signin Successfull", {
+      user: {
+        id: existingUser.id,
+        name: existingUser.name,
+        email: existingUser.email,
+        role: existingUser.role,
+        avatar: existingUser.avatar,
+        isEmailVerified: existingUser.isEmailVerified,
+        lastLoginAt: existingUser.lastLoginAt,
+        provider: existingUser.provider
+      }
+    });
+  }
+);
+
+//? LOGIN WITH GOOGLE
+export const googleOAuth = AsyncHandler(
+  async (req: Request, res: Response, next: NextFunction) => {
+    const data = req.user as GoogleProfile | undefined;
+
+    if (!data) {
+      return next(ApiError.unauthorized("Authenticated failed!"));
+    }
+
+    const userInfo = {
+      provider: data?.provider as "local" | "google" | "github",
+      providerId: data.id,
+      name: data.displayName,
+      email: data?.emails && data?.emails[0]?.value,
+      isEmailVerified:
+        (data?.emails && data?.emails[0]?.verified === true) || true,
+      avatar: data.profileUrl || (data.photos && data.photos[0].value),
+      ip: req.ip || "Unknown",
+      userAgent: req.get("user-agent") || req.headers["user-agent"] || "Unknown"
+    };
+
+    const existingUser = await OAuthService.handleOAuthLogin(userInfo, {
+      setAuthCookie: (
+        accessToken: string,
+        refreshToken: string,
+        sessionId: string
+      ) => {
+        setAuthCookies(res, accessToken, refreshToken, sessionId);
+      }
+    });
+
+    ApiResponse.ok(res, "Signin Successfull", {
+      user: {
+        id: existingUser.id,
+        name: existingUser.name,
+        email: existingUser.email,
+        role: existingUser.role,
+        avatar: existingUser.avatar,
+        isEmailVerified: existingUser.isEmailVerified,
+        lastLoginAt: existingUser.lastLoginAt,
+        provider: existingUser.provider
+      }
+    });
+  }
+);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/db/index.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/db/index.ts
@@ -1,0 +1,3 @@
+//? Export all schemas from schemas directory
+
+export * from "./schemas/user.schema";

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/db/schemas/schema.helper.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/db/schemas/schema.helper.ts
@@ -1,0 +1,9 @@
+import { timestamp } from "drizzle-orm/mysql-core";
+
+export const timestamps = {
+  createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+  updatedAt: timestamp("updated_at", { mode: "date" })
+    .defaultNow()
+    .onUpdateNow()
+    .notNull()
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/db/schemas/user.schema.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/db/schemas/user.schema.ts
@@ -1,0 +1,56 @@
+import {
+  mysqlTable,
+  serial,
+  varchar,
+  boolean,
+  timestamp,
+  int,
+  json,
+  uniqueIndex,
+  index,
+  mysqlEnum
+} from "drizzle-orm/mysql-core";
+import { timestamps } from "./schema.helper";
+
+export interface IAvatar {
+  public_id?: string;
+  url: string;
+  size?: number;
+}
+
+export const users = mysqlTable(
+  "users",
+  {
+    id: serial("id").primaryKey(),
+    name: varchar("name", { length: 100 }).notNull(),
+    email: varchar("email", { length: 255 }).notNull().unique(),
+    password: varchar("password", { length: 255 }),
+    role: mysqlEnum("role", ["user", "admin"]).default("user").notNull(),
+
+    provider: mysqlEnum("provider", ["local", "google", "github"])
+      .default("local")
+      .notNull(),
+    providerId: varchar("provider_id", { length: 255 }),
+
+    avatar: json("avatar").$type<IAvatar>(),
+
+    isEmailVerified: boolean("is_email_verified").default(false).notNull(),
+    lastLoginAt: timestamp("last_login_at"),
+    failedLoginAttempts: int("failed_login_attempts").default(0).notNull(),
+    lockUntil: timestamp("lock_until"),
+
+    isDeleted: boolean("is_deleted").default(false).notNull(),
+    deletedAt: timestamp("deleted_at"),
+    reActivateAvailableAt: timestamp("re_activate_available_at"),
+
+    ...timestamps
+  },
+  table => [
+    uniqueIndex("email_idx").on(table.email),
+    index("role_idx").on(table.role),
+    index("is_deleted_idx").on(table.isDeleted)
+  ]
+);
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/docs/swagger.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/docs/swagger.json
@@ -1,0 +1,275 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Hybrid Auth API",
+    "description": "Hybrid Auth API",
+    "version": "1.0.0"
+  },
+  "host": "localhost:9000/api",
+  "basePath": "/",
+  "schemes": ["http"],
+  "paths": {
+    "/v1/health/": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/verify-otp": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/signup": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "example": "any"
+                },
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                },
+                "role": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/signin": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                },
+                "password": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/profile": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      },
+      "patch": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/refresh-token": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/logout": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "email": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/forgot-password": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/reset-password": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/change-password": {
+      "post": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/delete-account": {
+      "delete": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/v1/auth/reactivate-account": {
+      "put": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/github": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/github/callback": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/google": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/auth/google/callback": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/github": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/github/callback": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/google": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/google/callback": {
+      "get": {
+        "description": "",
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/email-templates/delete-account.ejs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/email-templates/delete-account.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Delete Account Request</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      line-height: 1.6;
+      margin: 0;
+      padding: 20px;
+      color: #333;
+    }
+    p {
+      margin-bottom: 10px;
+    }
+    a {
+      color: #007bff;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <p>Hello <%= name %>,</p>
+  <p>We received a request to delete your account. If you confirm this action, your account will be permanently deleted.</p>
+  <p>To confirm, please click the link below:</p>
+  <a href="<%= deleteAccountUrl %>">Confirm Delete Account</a>
+  <p>If you did not request this action, please ignore this email or reply to let us know. Your account is still secure.</p>
+  <p>Thank you,</p>
+</body>
+</html>

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/email-templates/email-verification.ejs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/email-templates/email-verification.ejs
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify your email</title>
+</head>
+
+<body
+  style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #f4f4f7; margin: 0; padding: 0; color: #51545e;">
+  <div style="background-color: #f4f4f7; padding: 40px 0;">
+    <div
+      style="margin: 0 auto; background-color: #ffffff; padding: 40px 20px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05); max-width: 600px;">
+
+      <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #333333; font-size: 24px; font-weight: 700; margin: 0;">Verify your email</h1>
+      </div>
+
+      <p style="font-size: 16px; line-height: 1.6; margin-bottom: 24px; color: #51545e;">Hello <strong>
+          <%= name %>
+        </strong>,</p>
+
+      <p style="font-size: 16px; line-height: 1.6; margin-bottom: 30px; color: #51545e;">
+        Thank you for registering. Please use the following One-Time Password (OTP) to verify your email address. This
+        code is valid for 5 minutes.
+      </p>
+
+      <div style="text-align: center; margin-bottom: 30px;">
+        <div
+          style="display: inline-block; padding: 16px 40px; background-color: #f8fafc; border-radius: 8px; border: 1px solid #e2e8f0;">
+          <span
+            style="font-family: 'Courier New', Courier, monospace; font-size: 32px; font-weight: 700; letter-spacing: 6px; color: #1e293b;">
+            <%= code %>
+          </span>
+        </div>
+      </div>
+
+      <p style="font-size: 14px; line-height: 1.6; color: #64748b; margin-top: 24px;">
+        If you didn't request this verification, you can safely ignore this email.
+      </p>
+
+      <div style="margin-top: 40px; padding-top: 24px; border-top: 1px solid #e2e8f0; text-align: center;">
+        <p style="font-size: 12px; color: #94a3b8; margin: 0;">
+          &copy; <%= new Date().getFullYear() %>. All rights reserved.
+        </p>
+      </div>
+
+    </div>
+  </div>
+</body>
+
+</html>

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/email-templates/forgot-password.ejs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/email-templates/forgot-password.ejs
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify your OTP</title>
+</head>
+
+<body
+  style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; background-color: #f4f4f7; margin: 0; padding: 0; color: #51545e;">
+  <div style="background-color: #f4f4f7; padding: 40px 0;">
+    <div
+      style="margin: 0 auto; background-color: #ffffff; padding: 40px 20px; border-radius: 8px; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05); max-width: 600px;">
+
+      <div style="text-align: center; margin-bottom: 30px;">
+        <h1 style="color: #333333; font-size: 24px; font-weight: 700; margin: 0;">
+          Forgot Password - Verify OTP
+        </h1>
+      </div>
+
+      <p style="font-size: 16px; line-height: 1.6; margin-bottom: 24px; color: #51545e;">Hello <strong>
+          <%= name %>
+        </strong>,</p>
+
+      <p style="font-size: 16px; line-height: 1.6; margin-bottom: 30px; color: #51545e;">
+        Thank you for using our service. Please use the following One-Time Password (OTP) to verify your password reset
+        request. This
+        code is valid for 5 minutes.
+      </p>
+
+      <div style="text-align: center; margin-bottom: 30px;">
+        <div
+          style="display: inline-block; padding: 16px 40px; background-color: #f8fafc; border-radius: 8px; border: 1px solid #e2e8f0;">
+          <span
+            style="font-family: 'Courier New', Courier, monospace; font-size: 32px; font-weight: 700; letter-spacing: 6px; color: #1e293b;">
+            <%= code %>
+          </span>
+        </div>
+      </div>
+
+      <p style="font-size: 14px; line-height: 1.6; color: #64748b; margin-top: 24px;">
+        If you didn't request this request, you can safely ignore this email.
+      </p>
+
+      <div style="margin-top: 40px; padding-top: 24px; border-top: 1px solid #e2e8f0; text-align: center;">
+        <p style="font-size: 12px; color: #94a3b8; margin: 0;">
+          &copy; <%= new Date().getFullYear() %>. All rights reserved.
+        </p>
+      </div>
+
+    </div>
+  </div>
+</body>
+
+</html>

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/helpers/auth.helpers.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/helpers/auth.helpers.ts
@@ -1,0 +1,19 @@
+import { OTPType } from "@/types/user";
+import argon2 from "argon2";
+
+export async function hashPassword(password: string): Promise<string> {
+  return argon2.hash(password);
+}
+
+export async function verifyPassword(
+  password: string,
+  hash: string
+): Promise<boolean> {
+  return argon2.verify(hash, password);
+}
+
+export const buildRedisKey = (
+  email: string,
+  otpType: OTPType,
+  suffix: string
+) => `otp:${suffix}:${email}:${otpType}`;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/helpers/cookie.helper.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/helpers/cookie.helper.ts
@@ -1,0 +1,75 @@
+import { Response } from "express";
+import {
+  ACCESS_TOKEN_EXPIRY,
+  REFRESH_TOKEN_EXPIRY,
+  SESSION_EXPIRY
+} from "../constants/auth";
+import env from "../configs/env";
+
+const isProduction = env.NODE_ENV === "production";
+
+export const COOKIE_OPTIONS = {
+  httpOnly: true,
+  secure: isProduction,
+  sameSite: isProduction ? ("none" as const) : ("lax" as const),
+  path: "/"
+};
+
+export function setAuthCookies(
+  res: Response,
+  accessToken: string,
+  refreshToken: string,
+  sessionId: string
+) {
+  setCookies(res, [
+    {
+      cookie: "accessToken",
+      value: accessToken,
+      maxAge: ACCESS_TOKEN_EXPIRY
+    },
+    {
+      cookie: "refreshToken",
+      value: refreshToken,
+      maxAge: REFRESH_TOKEN_EXPIRY
+    },
+    {
+      cookie: "sid",
+      value: sessionId,
+      maxAge: SESSION_EXPIRY
+    }
+  ]);
+}
+
+export function clearAuthCookies(res: Response) {
+  clearCookie(res, "accessToken");
+  clearCookie(res, "refreshToken");
+  clearCookie(res, "sid");
+}
+
+export function clearCookie(
+  res: Response,
+  cookie: string = "sid",
+  path: string = "/"
+) {
+  res.clearCookie(cookie, {
+    ...COOKIE_OPTIONS,
+    path
+  });
+}
+
+type Cookie = {
+  cookie: string;
+  value: string;
+  maxAge: number;
+  path?: string;
+};
+
+export function setCookies(res: Response, cookies: Cookie[]) {
+  cookies.forEach(({ cookie, value, maxAge, path = "/" }) => {
+    res.cookie(cookie, value, {
+      ...COOKIE_OPTIONS,
+      path,
+      maxAge
+    });
+  });
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/helpers/token.helpers.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/helpers/token.helpers.ts
@@ -1,0 +1,50 @@
+import crypto from "node:crypto";
+
+export function generateOTP(length: number = 6, ttlMinutes: number = 5) {
+  const code = crypto
+    .randomInt(0, Math.pow(10, length))
+    .toString()
+    .padStart(length, "0");
+
+  const hashCode = crypto
+    .createHash("sha256")
+    .update(String(code))
+    .digest("hex");
+
+  const expiresAt = new Date(Date.now() + ttlMinutes * 60 * 1000).toISOString();
+
+  return { code, hashCode, expiresAt };
+}
+
+export function generateHashedToken(token: string): string {
+  return crypto.createHash("sha256").update(String(token)).digest("hex");
+}
+
+export function generateSecureToken(length: number = 32): string {
+  return crypto.randomBytes(length).toString("hex");
+}
+
+export function verifyHashedToken(token: string, hashedToken: string): boolean {
+  return (
+    crypto.createHash("sha256").update(String(token)).digest("hex") ===
+    hashedToken
+  );
+}
+
+export function generateTokenAndHashedToken(id: string) {
+  const cryptoSecret = process.env.CRYPTO_SECRET! || "secret";
+  const token = crypto
+    .createHmac("sha256", cryptoSecret)
+    .update(String(id))
+    .digest("hex");
+
+  const hashedToken = crypto
+    .createHash("sha256")
+    .update(String(token))
+    .digest("hex");
+  return { token, hashedToken };
+}
+
+export function generateUUID(): string {
+  return crypto.randomUUID();
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/error-handler.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/error-handler.ts
@@ -1,0 +1,40 @@
+import { Request, Response, NextFunction } from "express";
+import env from "../configs/env";
+
+import { logger } from "../utils/logger";
+import { ApiError } from "../utils/api-error";
+
+export const errorHandler = (
+  err: Error,
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (res.headersSent) {
+    return next(err);
+  }
+  let statusCode = 500;
+  let message = "Internal server error";
+  let errors: unknown;
+
+  if (err instanceof ApiError) {
+    statusCode = err.statusCode;
+    message = err.message;
+    errors = err.errors;
+  }
+
+  logger.error(
+    err,
+    `Error: ${message} | Status: ${statusCode} | Path: ${req.method} ${req.originalUrl}`
+  );
+
+  const response = {
+    success: false,
+    message,
+    statusCode,
+    ...(errors !== undefined && { errors }),
+    ...(env.NODE_ENV === "development" && { stack: err.stack })
+  };
+
+  res.status(statusCode).json(response);
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/not-found-handler.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/not-found-handler.ts
@@ -1,0 +1,10 @@
+import { Request, Response, NextFunction } from "express";
+import { ApiError } from "../utils/api-error";
+
+export const notFoundHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  throw ApiError.notFound(`Route ${req.method} ${req.originalUrl} not found`);
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/rate-limiter.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/rate-limiter.ts
@@ -1,0 +1,126 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextFunction, Request, Response } from "express";
+import { rateLimit } from "express-rate-limit";
+import { STATUS_CODES } from "../constants/status-codes";
+import { ApiError } from "../utils/api-error";
+
+export const rateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per window
+  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+  message: {
+    success: false,
+    message:
+      "Too many requests from this IP, please try again after 15 minutes",
+    status: 429
+  },
+  handler: (req: Request, res: Response, next: NextFunction, options: any) => {
+    next(new ApiError(STATUS_CODES.TOO_MANY_REQUESTS, options.message.message));
+  }
+});
+
+/**
+ * Stricter rate limiter for sensitive routes (e.g., auth, login)
+ */
+export const authRateLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000, // 1 hour
+  max: 5, // Limit each IP to 5 failed attempts per hour
+  handler: (req, res, next, options) => {
+    next(
+      ApiError.tooManyRequests(
+        "Too many login attempts, please try again after an hour"
+      )
+    );
+  }
+});
+
+/**
+ * Rate limiter for login route
+ */
+export const signinRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many login attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+/**
+ * Rate limiter for registration route
+ */
+export const signupRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many registration attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const otpRequestLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  max: 6,
+  message: {
+    success: false,
+    message: "Too many OTP requests. Please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const otpVerificationLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  max: 6,
+  message: {
+    success: false,
+    message: "Too many OTP verification attempts. Please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const resetPasswordLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 6,
+  message: {
+    success: false,
+    message: "Too many password reset attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const deleteAccountLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many account deletion attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+export const changePasswordLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message: {
+    success: false,
+    message: "Too many password change attempts, please try again later.",
+    statusCode: 429
+  },
+  standardHeaders: true,
+  legacyHeaders: false
+});

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/security-header.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/security-header.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Request, Response } from "express";
+import cors from "cors";
+import { Express } from "express";
+import helmet from "helmet";
+import env from "../configs/env";
+
+export const configureSecurityHeaders = (app: Express) => {
+  // Use Helmet to set various security-related HTTP headers
+  app.use(helmet());
+
+  // Configure CORS
+  app.use(
+    cors({
+      origin: env.CORS_ORIGIN || "*",
+      credentials: true,
+      methods: ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"]
+    })
+  );
+
+  // Additional custom security headers
+  app.use((req: Request, res: Response, next: NextFunction) => {
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("X-XSS-Protection", "1; mode=block");
+    next();
+  });
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/upload-file.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/upload-file.ts
@@ -1,0 +1,30 @@
+import multer from "multer";
+
+export const ALLOWED_FILE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "video/mp4",
+  "video/mpeg",
+  "video/quicktime",
+  "application/pdf"
+];
+
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+const storage = multer.memoryStorage();
+
+const fileFilter: multer.Options["fileFilter"] = (_req, file, cb) => {
+  if (!ALLOWED_FILE_TYPES.includes(file.mimetype)) {
+    return cb(null, false);
+  }
+  cb(null, true);
+};
+
+const upload = multer({
+  storage,
+  limits: { fileSize: MAX_FILE_SIZE },
+  fileFilter
+});
+
+export default upload;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/user-account-restriction.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/user-account-restriction.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextFunction, Response } from "express";
+import { UserRequest } from "../types/user";
+import db from "../configs/db";
+import { users } from "../db/schemas/user.schema";
+import { eq } from "drizzle-orm";
+import { ApiError } from "../utils/api-error";
+import { logger } from "../utils/logger";
+import { getRemainingTime } from "@/utils/date";
+
+export async function checkUserAccountRestriction(
+  req: UserRequest,
+  _res: Response,
+  next: NextFunction
+): Promise<void> {
+  try {
+    if (!req.user?.id) {
+      return next(ApiError.unauthorized("Unauthorized"));
+    }
+
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, parseInt(req?.user?.id || "0")));
+
+    if (!user) {
+      return next(ApiError.unauthorized("Unauthorized, please login."));
+    }
+
+    if (user.isDeleted || user.deletedAt) {
+      return next(ApiError.forbidden("Your account has been deactivated."));
+    }
+
+    if (user.lockUntil && user.lockUntil.getTime() > Date.now()) {
+      const remainingTime = getRemainingTime(user.lockUntil);
+
+      return next(
+        ApiError.forbidden(
+          `Your account has been locked. Please try again after ${remainingTime.minutes} minutes and ${remainingTime.seconds} seconds.`
+        )
+      );
+    }
+
+    if (!user.isEmailVerified) {
+      return next(
+        ApiError.forbidden("Email not verified. Please verify your email.")
+      );
+    }
+
+    return next();
+  } catch (err: any) {
+    logger.error(err?.message || err);
+    return next(ApiError.server("Something went wrong"));
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/validate-id.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/validate-id.ts
@@ -1,0 +1,14 @@
+import { ApiError } from "../utils/api-error";
+import { NextFunction, Request, Response } from "express";
+
+export const validateObjectId = (paramName: string = "id") => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const value =
+      req?.params[paramName] || req?.body[paramName] || req?.query[paramName];
+    if (!value || typeof value !== "string" || value.trim().length === 0) {
+      throw ApiError.badRequest(`Invalid ${paramName}`);
+    }
+
+    next();
+  };
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/validate-request.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/validate-request.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from "express";
+import z, { ZodError, type ZodObject } from "zod";
+
+import { ApiError } from "../utils/api-error";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const validateRequest = (schema: ZodObject<any>) => {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      schema.parse(req.body);
+
+      next();
+    } catch (error) {
+      if (!(error instanceof ZodError)) {
+        return next(error);
+      }
+
+      return next(
+        ApiError.badRequest(
+          "Invalid request data",
+          z.flattenError(error).fieldErrors || z.flattenError(error)
+        )
+      );
+    }
+  };
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/verify-auth.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/middlewares/verify-auth.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextFunction, Response } from "express";
+import { verifyAccessToken } from "../utils/jwt";
+import { ApiError } from "../utils/api-error";
+import { SessionData, UserRequest } from "../types/user";
+import redisClient from "@/configs/redis";
+
+export async function verifyAuthentication(
+  req: UserRequest,
+  _res: Response,
+  next: NextFunction
+): Promise<void> {
+  const authHeader = req.headers.authorization || "";
+  const token = authHeader.startsWith("Bearer ")
+    ? authHeader.split(" ")[1]
+    : null;
+
+  const accessToken = req.cookies?.accessToken || token;
+  if (!accessToken) {
+    return next(ApiError.unauthorized("Missing access token"));
+  }
+
+  try {
+    const decoded = verifyAccessToken(accessToken);
+
+    const sessionKey = `session:${decoded.sessionId}`;
+    const sessionData = await redisClient.get(sessionKey);
+    if (!sessionData) {
+      return next(ApiError.unauthorized("Session not found"));
+    }
+
+    let session: SessionData;
+
+    try {
+      session = JSON.parse(sessionData) as SessionData;
+    } catch {
+      return next(ApiError.unauthorized("Invalid session"));
+    }
+
+    if (session.ip !== req.ip) {
+      return next(ApiError.unauthorized("Suspicious session"));
+    }
+
+    if (session.userAgent !== req.headers["user-agent"]) {
+      return next(ApiError.unauthorized("Suspicious session"));
+    }
+
+    if (session.expiresAt < new Date()) {
+      return next(ApiError.unauthorized("Session expired"));
+    }
+
+    req.user = {
+      ...decoded,
+      id: decoded._id
+    };
+    return next();
+  } catch (err: any) {
+    if (err.name === "TokenExpiredError") {
+      return next(ApiError.unauthorized("Access token expired"));
+    }
+    return next(ApiError.unauthorized("Invalid access token"));
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/routes/auth.routes.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/routes/auth.routes.ts
@@ -1,0 +1,148 @@
+import { Router } from "express";
+import { validateRequest } from "../middlewares/validate-request";
+import {
+  ChangePasswordSchema,
+  DeleteAccountSchema,
+  RequestOtpSchema,
+  ResetPasswordSchema,
+  SigninSchema,
+  SignupSchema,
+  UpdateProfileSchema,
+  VerifyOtpSchema
+} from "../validators/auth";
+import {
+  changePassword,
+  deleteAccount,
+  deleteAllUserSessions,
+  deleteUserSession,
+  forgotPassword,
+  getUserProfile,
+  getUserSessions,
+  logoutUser,
+  reactivateAccount,
+  refreshToken,
+  requestDeleteAccount,
+  resetPassword,
+  signinUser,
+  signupUser,
+  updateProfile,
+  verifyResetPasswordOtp,
+  verifyUser
+} from "../controllers/auth.controller";
+import { verifyAuthentication } from "../middlewares/verify-auth";
+import { checkUserAccountRestriction } from "../middlewares/user-account-restriction";
+import {
+  changePasswordLimiter,
+  deleteAccountLimiter,
+  otpRequestLimiter,
+  resetPasswordLimiter,
+  signinRateLimiter,
+  signupRateLimiter
+} from "../middlewares/rate-limiter";
+import upload from "../middlewares/upload-file";
+
+const router = Router();
+
+router.post(
+  "/signup",
+  validateRequest(SignupSchema),
+  signupRateLimiter,
+  signupUser
+);
+
+router.post("/verify-user", validateRequest(VerifyOtpSchema), verifyUser);
+
+router.post(
+  "/signin",
+  validateRequest(SigninSchema),
+  signinRateLimiter,
+  signinUser
+);
+
+router.get("/profile", verifyAuthentication, getUserProfile);
+
+router.patch(
+  "/profile",
+  upload.single("avatar"),
+  validateRequest(UpdateProfileSchema),
+  verifyAuthentication,
+  checkUserAccountRestriction,
+  updateProfile
+);
+
+router.get("/sessions", verifyAuthentication, getUserSessions);
+
+router.delete(
+  "/sessions",
+  verifyAuthentication,
+  checkUserAccountRestriction,
+  deleteAllUserSessions
+);
+
+router.delete(
+  "/sessions/:sessionId",
+  verifyAuthentication,
+  checkUserAccountRestriction,
+  deleteUserSession
+);
+
+router.post("/refresh-token", refreshToken);
+
+router.post(
+  "/logout",
+  verifyAuthentication,
+  checkUserAccountRestriction,
+  logoutUser
+);
+
+router.post(
+  "/forgot-password",
+  validateRequest(RequestOtpSchema.pick({ email: true })),
+  otpRequestLimiter,
+  forgotPassword
+);
+
+router.post(
+  "/verify-reset-otp",
+  validateRequest(VerifyOtpSchema),
+  otpRequestLimiter,
+  verifyResetPasswordOtp
+);
+
+router.post(
+  "/reset-password",
+  validateRequest(ResetPasswordSchema),
+  resetPasswordLimiter,
+  resetPassword
+);
+
+router.post(
+  "/change-password",
+  verifyAuthentication,
+  validateRequest(ChangePasswordSchema),
+  checkUserAccountRestriction,
+  changePasswordLimiter,
+  changePassword
+);
+
+router.post(
+  "/account/request-delete",
+  verifyAuthentication,
+  validateRequest(SigninSchema.pick({ password: true })),
+  checkUserAccountRestriction,
+  deleteAccountLimiter,
+  requestDeleteAccount
+);
+
+router.delete(
+  "/account/delete",
+  verifyAuthentication,
+  validateRequest(DeleteAccountSchema),
+  checkUserAccountRestriction,
+  deleteAccountLimiter,
+  deleteAccount
+);
+
+router.put("/account/reactivate", verifyAuthentication, reactivateAccount);
+
+export default router;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/routes/health.routes.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/routes/health.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { healthCheck } from "../controllers/health.controller";
+
+const router = Router();
+
+router.get("/", healthCheck);
+
+export default router;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/routes/index.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/routes/index.ts
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import healthRoutes from "./health.routes";
+import authRoutes from "./auth.routes";
+import oauthRoutes from "./oauth.routes";
+
+const router = Router();
+
+router.use("/v1/health", healthRoutes);
+router.use("/v1/auth", authRoutes);
+router.use("/auth", oauthRoutes); //* Here versioning is not given because, in google and github callback routes, we are not using versioning. process.env.GOOGLE_REDIRECT_URI
+
+export default router;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/routes/oauth.routes.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/routes/oauth.routes.ts
@@ -1,0 +1,38 @@
+import { Router } from "express";
+import passport from "passport";
+import { githubOAuth, googleOAuth } from "../controllers/oauth.controller";
+
+const router = Router();
+
+router.get(
+  "/github",
+  passport.authenticate("github", { scope: ["user:email"] })
+);
+
+router.get(
+  "/github/callback",
+  passport.authenticate("github", {
+    failureRedirect: "/login", //? redirect route if authenticated is failed,
+    session: false
+  }),
+  githubOAuth
+);
+
+router.get(
+  "/google",
+  passport.authenticate("google", {
+    scope: ["email", "profile", "openid"],
+    prompt: "consent"
+  })
+);
+
+router.get(
+  "/google/callback",
+  passport.authenticate("google", {
+    failureRedirect: "/login", //? redirect route if authenticated is failed
+    session: false
+  }),
+  googleOAuth
+);
+
+export default router;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/server.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/server.ts
@@ -1,0 +1,32 @@
+import app from "./app";
+import env from "./configs/env";
+import redisClient from "./configs/redis";
+import { logger } from "./utils/logger";
+import { configureGracefulShutdown } from "./utils/shutdown";
+
+const port = env.PORT || 9000;
+
+redisClient
+  .connect()
+  .then(() => {
+    logger.info("Redis Connection Success");
+    const server = app.listen(port, () => {
+      logger.info("Hybrid Auth API started successfully");
+      logger.info(`URL          : http://localhost:${port}`);
+      logger.info(`Environment  : ${env.NODE_ENV}`);
+      logger.info(
+        `Version      : ${process.env.npm_package_version ?? "unknown"}`
+      );
+      logger.info(`Started At   : ${new Date().toISOString()}`);
+
+      if (env.NODE_ENV !== "production") {
+        logger.info(`API Docs     : http://localhost:${port}/api/docs`);
+      }
+    });
+
+    configureGracefulShutdown(server);
+  })
+  .catch((error: Error) => {
+    logger.error(error, "Redis Connection Failed");
+    process.exit(1);
+  });

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/services/auth.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/services/auth.service.ts
@@ -1,0 +1,889 @@
+import { NextFunction } from "express";
+import db from "../configs/db";
+import { users } from "../db/schemas/user.schema";
+import { eq } from "drizzle-orm";
+import { ApiError } from "../utils/api-error";
+import { hashPassword, verifyPassword } from "../helpers/auth.helpers";
+import { SignupUserType, VerifyOtpType } from "../validators/auth";
+import {
+  DELETE_ACCOUNT_TOKEN_EXPIRY,
+  LOCK_TIME_MS,
+  LOGIN_MAX_ATTEMPTS,
+  OTP_CODE_LENGTH,
+  OTP_EXPIRES_IN,
+  REACTIVATION_AVAILABLE_AT,
+  REFRESH_TOKEN_EXPIRY,
+  RESET_PASSWORD_TOKEN_EXPIRY,
+  SESSION_EXPIRY
+} from "../constants/auth";
+import {
+  generateAccessToken,
+  generateRefreshToken,
+  verifyAccessToken,
+  verifyRefreshToken
+} from "../utils/jwt";
+import {
+  generateHashedToken,
+  generateOTP,
+  generateSecureToken,
+  generateUUID
+} from "../helpers/token.helpers";
+import { AvatarData, RefreshTokenData, SessionData } from "../types/user";
+import { OtpService } from "./otp.service";
+import { deleteFileFromCloudinary } from "./cloudinary.service";
+import redisClient from "../configs/redis";
+import { logger } from "../utils/logger";
+import env from "../configs/env";
+import { sendEmail } from "../utils/send-mail";
+import { getRemainingTime } from "../utils/date";
+
+export type CookieOptionsType = {
+  setAuthCookie?: (
+    accessToken: string,
+    refreshToken: string,
+    sessionId: string
+  ) => void;
+};
+
+export class AuthService {
+  static async registerUser(user: Omit<SignupUserType, "confirmPassword">) {
+    try {
+      const { name, email, password, role } = user;
+      const [existingUser] = await db
+        .select()
+        .from(users)
+        .where(eq(users.email, email));
+
+      if (existingUser) {
+        throw ApiError.conflict("User with this email already exists");
+      }
+
+      const pending = await redisClient.get(`user:pending:${email}`);
+
+      if (pending) {
+        throw ApiError.conflict(
+          "Signup already in progress. Check your email for OTP."
+        );
+      }
+
+      const hashedPassword = await hashPassword(password);
+
+      await OtpService.checkOtpRestrictions(email);
+      await OtpService.trackOtpRequests(email);
+
+      const { code, hashCode } = generateOTP(OTP_CODE_LENGTH);
+
+      const redisKey = `user:${email}:${hashCode}`;
+      const indexKey = `user:pending:${email}`;
+      const userData = JSON.stringify({
+        name,
+        email,
+        role,
+        password: hashedPassword
+      });
+
+      await OtpService.sendOtp({
+        name,
+        email,
+        templateName: "email-verification",
+        code,
+        hashCode,
+        subject: "Email Verification"
+      });
+
+      try {
+        await redisClient.set(redisKey, userData, {
+          expiration: {
+            type: "PX",
+            value: OTP_EXPIRES_IN
+          }
+        });
+
+        await redisClient.set(indexKey, hashCode, {
+          expiration: {
+            type: "PX",
+            value: OTP_EXPIRES_IN
+          }
+        });
+      } catch (error) {
+        await Promise.allSettled([
+          redisClient.del(redisKey),
+          redisClient.del(indexKey),
+          redisClient.del(`otp:${email}`),
+          redisClient.del(`otp_cooldown:${email}`)
+        ]);
+
+        throw error;
+      }
+    } catch (error) {
+      logger.error(error, "Failed to register user");
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw ApiError.server("Failed to register user");
+    }
+  }
+
+  static async verifyUser({ email, otpCode }: VerifyOtpType) {
+    const hashCode = generateHashedToken(otpCode);
+
+    await OtpService.verifyOtp(hashCode, email);
+
+    const userData = await redisClient.get(`user:${email}:${hashCode}`);
+
+    if (!userData) {
+      throw ApiError.badRequest("Invalid or expired otp");
+    }
+
+    const { name, email: userEmail, role, password } = JSON.parse(userData);
+
+    const [user] = await db
+      .insert(users)
+      .values({
+        name,
+        email: userEmail,
+        role,
+        password,
+        isEmailVerified: true
+      })
+      .$returningId();
+
+    await redisClient.del(`user:${email}:${hashCode}`);
+    await redisClient.del(`user:pending:${email}`);
+
+    return {
+      _id: user.id,
+      name,
+      email,
+      role: role,
+      isEmailVerified: true
+    };
+  }
+
+  static async signinUser(
+    {
+      email,
+      password,
+      ip,
+      userAgent
+    }: {
+      email: string;
+      password: string;
+      ip: string;
+      userAgent: string;
+    },
+    setCookie: CookieOptionsType
+  ) {
+    try {
+      const [user] = await db
+        .select()
+        .from(users)
+        .where(eq(users.email, email));
+
+      if (!user) {
+        throw ApiError.unauthorized("Invalid credentials");
+      }
+
+      if (!user.isEmailVerified) {
+        throw ApiError.unauthorized("Email not verified");
+      }
+
+      if (user.lockUntil && new Date() < user.lockUntil) {
+        throw ApiError.forbidden(
+          `Your account has been locked. Please try again after ${getRemainingTime(user.lockUntil).minutes} minutes and ${getRemainingTime(user.lockUntil).seconds} seconds.`
+        );
+      }
+
+      const isPasswordValid = await verifyPassword(
+        password,
+        user.password || ""
+      );
+      if (!isPasswordValid) {
+        let lockUntil = null;
+
+        let newAttempts = user.failedLoginAttempts + 1;
+
+        if (newAttempts >= LOGIN_MAX_ATTEMPTS) {
+          lockUntil = new Date(Date.now() + LOCK_TIME_MS);
+        }
+
+        await db
+          .update(users)
+          .set({
+            failedLoginAttempts: newAttempts,
+            lockUntil
+          })
+          .where(eq(users.id, user.id));
+
+        throw ApiError.unauthorized("Invalid credentials");
+      }
+
+      await db
+        .update(users)
+        .set({
+          failedLoginAttempts: 0,
+          lockUntil: null
+        })
+        .where(eq(users.id, user.id));
+
+      await AuthService.handleToken(
+        {
+          _id: user.id,
+          role: user.role as "user" | "admin",
+          ip,
+          userAgent
+        },
+        setCookie
+      );
+
+      return {
+        id: user.id,
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        isEmailVerified: user.isEmailVerified
+      };
+    } catch (err) {
+      if (err instanceof ApiError) {
+        throw err;
+      }
+      throw ApiError.server("Signin failed");
+    }
+  }
+
+  static async handleToken(
+    user: { _id: number; role: "user" | "admin" } & {
+      ip: string;
+      userAgent: string;
+    },
+    context: CookieOptionsType
+  ) {
+    const sessionId = generateUUID();
+
+    const accessToken = generateAccessToken({
+      _id: user._id.toString(),
+      role: user.role,
+      sessionId
+    });
+
+    const refreshToken = generateRefreshToken({
+      _id: user._id.toString(),
+      sessionId
+    });
+
+    const hashedRefreshToken = generateHashedToken(refreshToken);
+
+    const refreshTokenData: RefreshTokenData = {
+      userId: user._id.toString(),
+      tokenHash: hashedRefreshToken,
+      expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY)
+    };
+
+    const sessionData: SessionData = {
+      userId: user._id.toString(),
+      sessionId,
+      refreshTokenHash: hashedRefreshToken,
+      userAgent: user.userAgent,
+      ip: user.ip,
+      createdAt: new Date(),
+      expiresAt: new Date(Date.now() + SESSION_EXPIRY)
+    };
+
+    const refreshTokenKey = `refreshToken:${hashedRefreshToken}`;
+
+    await redisClient.set(refreshTokenKey, JSON.stringify(refreshTokenData), {
+      expiration: {
+        type: "PX",
+        value: REFRESH_TOKEN_EXPIRY
+      }
+    });
+
+    const sessionKey = `session:${sessionId}`;
+
+    const userSessionsKey = `user_sessions:${user._id}`;
+
+    await redisClient.set(sessionKey, JSON.stringify(sessionData), {
+      expiration: {
+        type: "PX",
+        value: SESSION_EXPIRY
+      }
+    });
+
+    // add sessionId to user's set
+    await redisClient.sAdd(userSessionsKey, sessionId);
+
+    context.setAuthCookie &&
+      context.setAuthCookie(accessToken, refreshToken, sessionId);
+
+    await db
+      .update(users)
+      .set({
+        lastLoginAt: new Date(),
+        failedLoginAttempts: 0,
+        lockUntil: null
+      })
+      .where(eq(users.id, user._id));
+  }
+
+  static async getUserProfile(userId: string) {
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, parseInt(userId)));
+
+    return user;
+  }
+
+  static async refreshTokens(accessToken: string | null, refreshToken: string) {
+    if (!refreshToken) {
+      throw ApiError.unauthorized("Unauthorized, please login.");
+    }
+
+    const decodedRefresh = verifyRefreshToken(refreshToken);
+
+    if (!decodedRefresh?._id) {
+      throw ApiError.unauthorized("Invalid refresh token.");
+    }
+
+    const refreshTokenHash = generateHashedToken(refreshToken);
+
+    const refreshTokenKey = `refreshToken:${refreshTokenHash}`;
+    const sessionKey = `session:${decodedRefresh.sessionId}`;
+
+    await redisClient.watch([refreshTokenKey, sessionKey]);
+
+    try {
+      const [storedToken, session] = await Promise.all([
+        redisClient.get(refreshTokenKey),
+        redisClient.get(sessionKey)
+      ]);
+
+      if (!storedToken) {
+        throw ApiError.unauthorized("Invalid refresh token.");
+      }
+
+      const { userId, tokenHash, expiresAt } = JSON.parse(
+        storedToken
+      ) as RefreshTokenData;
+
+      if (userId !== decodedRefresh._id || tokenHash !== refreshTokenHash) {
+        throw ApiError.unauthorized("Invalid refresh token.");
+      }
+
+      if (new Date(expiresAt) < new Date()) {
+        throw ApiError.unauthorized("Refresh token expired.");
+      }
+
+      if (!session) {
+        throw ApiError.unauthorized("Session not found.");
+      }
+
+      const storedSessionData = JSON.parse(session) as SessionData;
+
+      if (
+        decodedRefresh.sessionId !== storedSessionData.sessionId ||
+        decodedRefresh._id !== storedSessionData.userId ||
+        storedSessionData.refreshTokenHash !== refreshTokenHash
+      ) {
+        throw ApiError.unauthorized("Token-session mismatch");
+      }
+
+      if (accessToken) {
+        try {
+          const decodedAccess = verifyAccessToken(accessToken);
+          if (decodedAccess._id !== decodedRefresh._id) {
+            throw ApiError.unauthorized("Token mismatch.");
+          }
+        } catch (e) {
+          // Access token might be expired, which is normal for a refresh flow
+        }
+      }
+
+      const [user] = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, parseInt(decodedRefresh._id)));
+      if (!user) {
+        throw ApiError.unauthorized("User not found.");
+      }
+
+      const newAccessToken = generateAccessToken({
+        _id: user.id.toString(),
+        role: user.role as "user" | "admin",
+        sessionId: storedSessionData.sessionId
+      });
+
+      const newRefreshToken = generateRefreshToken({
+        _id: user.id.toString(),
+        sessionId: storedSessionData.sessionId
+      });
+      const newRefreshTokenHash = generateHashedToken(newRefreshToken);
+
+      const refreshTokenData: RefreshTokenData = {
+        userId: user.id.toString(),
+        tokenHash: newRefreshTokenHash,
+        expiresAt: new Date(Date.now() + REFRESH_TOKEN_EXPIRY)
+      };
+      const sessionData: SessionData = {
+        userId: user.id.toString(),
+        sessionId: storedSessionData.sessionId,
+        refreshTokenHash: newRefreshTokenHash,
+        userAgent: storedSessionData.userAgent,
+        ip: storedSessionData.ip,
+        createdAt: storedSessionData.createdAt,
+        expiresAt: new Date(Date.now() + SESSION_EXPIRY)
+      };
+
+      const newRefreshTokenKey = `refreshToken:${newRefreshTokenHash}`;
+      const transaction = redisClient.multi();
+
+      transaction.del(`refreshToken:${tokenHash}`);
+      transaction.set(newRefreshTokenKey, JSON.stringify(refreshTokenData), {
+        expiration: {
+          type: "PX",
+          value: REFRESH_TOKEN_EXPIRY
+        }
+      });
+      transaction.set(sessionKey, JSON.stringify(sessionData), {
+        expiration: {
+          type: "PX",
+          value: SESSION_EXPIRY
+        }
+      });
+
+      const transactionResult = await transaction.exec();
+
+      if (!transactionResult) {
+        throw ApiError.unauthorized("Refresh token already rotated.");
+      }
+
+      return {
+        accessToken: newAccessToken,
+        refreshToken: newRefreshToken,
+        sessionId: storedSessionData.sessionId
+      };
+    } finally {
+      await redisClient.unwatch();
+    }
+  }
+
+  static async logoutUser(userId: string, sessionId: string) {
+    const sessionKey = `session:${sessionId}`;
+    const sessionData = await redisClient.get(sessionKey);
+    const userSessionsKey = `user_sessions:${userId}`;
+    if (!sessionData) {
+      throw ApiError.unauthorized("Session not found.");
+    }
+
+    const session = JSON.parse(sessionData) as SessionData;
+
+    if (session.userId !== userId) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    const refreshTokenKey = `refreshToken:${session.refreshTokenHash}`;
+
+    await redisClient.del(sessionKey);
+    await redisClient.del(refreshTokenKey);
+    await redisClient.sRem(userSessionsKey, sessionId);
+  }
+
+  static async forgotPassword(email: string) {
+    const [user] = await db.select().from(users).where(eq(users.email, email));
+
+    if (!user) {
+      return;
+    }
+
+    const { code, hashCode } = generateOTP(OTP_CODE_LENGTH);
+
+    await OtpService.checkOtpRestrictions(email);
+    await OtpService.trackOtpRequests(email);
+
+    const redisKey = `reset_password:${email}:${hashCode}`;
+
+    await redisClient.set(redisKey, hashCode, {
+      expiration: {
+        type: "PX",
+        value: RESET_PASSWORD_TOKEN_EXPIRY
+      }
+    });
+
+    await OtpService.sendOtp({
+      email,
+      subject: "Password Reset",
+      templateName: "forgot-password",
+      name: user.name,
+      code,
+      hashCode
+    });
+  }
+
+  static async verifyResetPasswordOtp(otpCode: string, email: string) {
+    const hashedCode = generateHashedToken(otpCode);
+
+    const redisKey = `reset_password:${email}:${hashedCode}`;
+    const storedHashCode = await redisClient.get(redisKey);
+    if (!storedHashCode) {
+      throw ApiError.unauthorized("Invalid or expired otp");
+    }
+    await OtpService.verifyOtp(storedHashCode, email);
+
+    await redisClient.del(`reset_password:${email}:${hashedCode}`);
+    await redisClient.set(`reset_password:status:${email}`, "pending", {
+      expiration: {
+        type: "PX",
+        value: RESET_PASSWORD_TOKEN_EXPIRY
+      }
+    });
+  }
+
+  static async getUserSessions(userId: string, currentSessionId: string) {
+    const userSessionsKey = `user_sessions:${userId}`;
+    const sessionIds = await redisClient.sMembers(userSessionsKey);
+
+    const sessions = [];
+    for (const sessionId of sessionIds) {
+      const sessionKey = `session:${sessionId}`;
+      const sessionData = await redisClient.get(sessionKey);
+      if (sessionData) {
+        const session = JSON.parse(sessionData) as SessionData;
+        sessions.push({
+          ...session,
+          isCurrent: sessionId === currentSessionId
+        });
+      }
+    }
+
+    return sessions;
+  }
+
+  static async deleteSession(userId: string, sessionId: string) {
+    const sessionKey = `session:${sessionId}`;
+    const sessionData = await redisClient.get(sessionKey);
+    const userSessionsKey = `user_sessions:${userId}`;
+
+    if (!sessionData) {
+      throw ApiError.notFound("Session not found.");
+    }
+
+    const session = JSON.parse(sessionData) as SessionData;
+
+    if (session.userId !== userId) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    const refreshTokenKey = `refreshToken:${session.refreshTokenHash}`;
+
+    await redisClient.del(sessionKey);
+    await redisClient.del(refreshTokenKey);
+    await redisClient.sRem(userSessionsKey, sessionId);
+  }
+
+  static async deleteAllUserSessions(userId: string) {
+    const userSessionsKey = `user_sessions:${userId}`;
+    const sessionIds = await redisClient.sMembers(userSessionsKey);
+
+    if (sessionIds.length === 0) {
+      return;
+    }
+
+    const sessions = await Promise.all(
+      sessionIds.map(async sessionId => {
+        const sessionKey = `session:${sessionId}`;
+        const sessionData = await redisClient.get(sessionKey);
+
+        return {
+          sessionKey,
+          session: sessionData ? (JSON.parse(sessionData) as SessionData) : null
+        };
+      })
+    );
+
+    await Promise.all(
+      sessions.flatMap(({ sessionKey, session }) => {
+        const deletions = [redisClient.del(sessionKey)];
+
+        if (session?.refreshTokenHash) {
+          deletions.push(
+            redisClient.del(`refreshToken:${session.refreshTokenHash}`)
+          );
+        }
+
+        return deletions;
+      })
+    );
+
+    await redisClient.del(userSessionsKey);
+  }
+
+  static async resetPassword(
+    next: NextFunction,
+    email: string,
+    newPassword: string
+  ) {
+    const [user] = await db.select().from(users).where(eq(users.email, email));
+
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    if (user.lockUntil && new Date(user.lockUntil) > new Date()) {
+      throw ApiError.forbidden(
+        `Your account has been locked. Please try again after ${
+          getRemainingTime(user.lockUntil).minutes
+        } minutes and ${getRemainingTime(user.lockUntil).seconds} seconds.`
+      );
+    }
+
+    if (user.failedLoginAttempts >= LOGIN_MAX_ATTEMPTS && user.lockUntil) {
+      throw ApiError.forbidden(
+        `You have exceeded the maximum number of login attempts. Please try again after ${
+          getRemainingTime(user.lockUntil).minutes
+        } minutes and ${getRemainingTime(user.lockUntil).seconds} seconds.`
+      );
+    }
+
+    if (!user.isEmailVerified) {
+      throw ApiError.unauthorized("Please verify your email first.");
+    }
+
+    const redisKey = `reset_password:status:${email}`;
+    const status = await redisClient.get(redisKey);
+    if (status !== "pending") {
+      throw ApiError.unauthorized(
+        "Please request a password reset before attempting to set a new password."
+      );
+    }
+
+    const oldPassword = user.password;
+
+    const isOldPassword = await verifyPassword(
+      newPassword,
+      oldPassword as string
+    );
+
+    if (isOldPassword) {
+      throw ApiError.badRequest("New password should be different!");
+    }
+
+    const hashedPassword = await hashPassword(newPassword);
+    await db
+      .update(users)
+      .set({ password: hashedPassword })
+      .where(eq(users.email, email));
+    await redisClient.del(`reset_password:status:${email}`);
+
+    //? Delete all user sessions
+    await this.deleteAllUserSessions(user.id.toString());
+
+    return {
+      message: "Password reset successfully. Please login!"
+    };
+  }
+
+  static async changePassword(
+    next: NextFunction,
+    {
+      newPassword,
+      oldPassword,
+      userId
+    }: {
+      userId: string;
+      newPassword: string;
+      oldPassword: string;
+    }
+  ) {
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, parseInt(userId)));
+
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    if (!user.isEmailVerified) {
+      throw ApiError.unauthorized("Please verify your email first.");
+    }
+
+    const isOldPassword = await verifyPassword(
+      oldPassword,
+      user.password || ""
+    );
+
+    if (!isOldPassword) {
+      throw ApiError.unauthorized("Invalid credentials");
+    }
+
+    if (newPassword === oldPassword) {
+      throw ApiError.badRequest("New password should be different!");
+    }
+
+    const hashedPassword = await hashPassword(newPassword);
+    await db
+      .update(users)
+      .set({ password: hashedPassword })
+      .where(eq(users.id, parseInt(userId)));
+
+    await this.deleteAllUserSessions(userId);
+
+    return {
+      message: "Password changed successfully. Please login again!"
+    };
+  }
+
+  static async requestDeleteAccount(userId: string, password: string) {
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, parseInt(userId)));
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    const isPasswordValid = await verifyPassword(password, user.password || "");
+
+    if (!isPasswordValid) {
+      let lockUntil = null;
+
+      let newAttempts = user.failedLoginAttempts + 1;
+
+      if (newAttempts >= LOGIN_MAX_ATTEMPTS) {
+        lockUntil = new Date(Date.now() + LOCK_TIME_MS);
+      }
+
+      await db
+        .update(users)
+        .set({
+          failedLoginAttempts: newAttempts,
+          lockUntil
+        })
+        .where(eq(users.id, user.id));
+      throw ApiError.unauthorized("Invalid credentials");
+    }
+
+    const token = generateSecureToken();
+    const hashedToken = generateHashedToken(token);
+
+    const redisKey = `delete_account:token:${userId}`;
+
+    if (await redisClient.get(redisKey)) {
+      throw ApiError.badRequest("Delete account token already requested!");
+    }
+
+    await redisClient.set(redisKey, hashedToken, {
+      expiration: {
+        type: "PX",
+        value: DELETE_ACCOUNT_TOKEN_EXPIRY
+      }
+    });
+
+    const deleteAccountUrl = `${env.CLIENT_URL}/account/delete?token=${token}`;
+    logger.info({ userId }, "Delete account email queued");
+    await sendEmail({
+      email: user.email,
+      subject: "Delete Account Request",
+      templateName: "delete-account",
+      data: {
+        name: user.name,
+        deleteAccountUrl
+      }
+    });
+  }
+
+  static async deleteOrDeactiveAccount({
+    userId,
+    type,
+    token
+  }: {
+    userId: string;
+    type: "soft" | "hard";
+    token: string;
+  }) {
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, parseInt(userId)));
+
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    const redisKey = `delete_account:token:${userId}`;
+    const storedToken = await redisClient.get(redisKey);
+    if (!storedToken) {
+      throw ApiError.badRequest("Invalid or expired token!");
+    }
+
+    const isTokenValid = generateHashedToken(token) === storedToken;
+    if (!isTokenValid) {
+      throw ApiError.badRequest("Invalid or expired token!");
+    }
+
+    await redisClient.del(redisKey);
+
+    if (type === "soft") {
+      await db
+        .update(users)
+        .set({
+          isDeleted: true,
+          deletedAt: new Date(),
+          reActivateAvailableAt: new Date(
+            Date.now() + REACTIVATION_AVAILABLE_AT
+          )
+        })
+        .where(eq(users.id, parseInt(userId)));
+      await AuthService.deleteAllUserSessions(userId);
+    } else if (type === "hard") {
+      const avatar = user.avatar as AvatarData | string | null | undefined;
+
+      if (avatar && typeof avatar !== "string" && avatar.public_id) {
+        await deleteFileFromCloudinary([avatar.public_id]);
+      }
+      await db.delete(users).where(eq(users.id, parseInt(userId)));
+      await AuthService.deleteAllUserSessions(userId);
+    }
+  }
+
+  static async reactivateAccount(userId: string) {
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, parseInt(userId)));
+    if (!user) {
+      throw ApiError.unauthorized("Unauthorized access");
+    }
+
+    if (user.lockUntil && new Date(user.lockUntil) > new Date()) {
+      const remainingTime = getRemainingTime(user.lockUntil);
+      throw ApiError.badRequest(
+        `Your account has been locked. Please try again after ${remainingTime.minutes} minutes and ${remainingTime.seconds} seconds.`
+      );
+    }
+
+    if (!user?.isDeleted || !user?.deletedAt) {
+      throw ApiError.badRequest("Your account is already active!");
+    }
+
+    if (
+      user?.reActivateAvailableAt &&
+      new Date(user?.reActivateAvailableAt) > new Date()
+    ) {
+      throw ApiError.forbidden(
+        `Your account has been locked. Please try again after ${
+          getRemainingTime(user.reActivateAvailableAt).minutes
+        } minutes and ${getRemainingTime(user.reActivateAvailableAt).seconds} seconds.`
+      );
+    }
+
+    await db
+      .update(users)
+      .set({
+        isDeleted: false,
+        deletedAt: null,
+        reActivateAvailableAt: null
+      })
+      .where(eq(users.id, parseInt(userId)));
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/services/cloudinary.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/services/cloudinary.service.ts
@@ -1,0 +1,52 @@
+import { DeleteApiResponse } from "cloudinary";
+import cloudinary from "../configs/cloudinary";
+
+export interface UploadOptions {
+  folder: string;
+  resource_type?: "image" | "video" | "raw" | "auto";
+}
+
+export interface CloudinaryUploadResult {
+  url: string;
+  public_id: string;
+  size: number;
+}
+
+export const uploadToCloudinary = (
+  buffer: Buffer,
+  options: UploadOptions
+): Promise<CloudinaryUploadResult> => {
+  return new Promise((resolve, reject) => {
+    const stream = cloudinary.uploader.upload_stream(
+      {
+        folder: options.folder || "uploads",
+        resource_type: options.resource_type || "auto"
+      },
+      (error, result) => {
+        if (error || !result) {
+          return reject(error);
+        }
+        resolve({
+          url: result.secure_url,
+          public_id: result.public_id,
+          size: result.bytes
+        });
+      }
+    );
+
+    stream.end(buffer);
+  });
+};
+
+export const deleteFileFromCloudinary = (
+  publicIds: string[]
+): Promise<DeleteApiResponse> => {
+  return new Promise((resolve, reject) => {
+    cloudinary.api.delete_resources(publicIds, (error, result) => {
+      if (error || !result) {
+        return reject(error);
+      }
+      resolve(result);
+    });
+  });
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/services/oauth.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/services/oauth.service.ts
@@ -1,0 +1,97 @@
+import { AuthService, CookieOptionsType } from "./auth.service";
+import db from "../configs/db";
+import { users } from "../db/schemas/user.schema";
+import { eq } from "drizzle-orm";
+import { ApiError } from "../utils/api-error";
+
+type OAuthProfile = {
+  provider: "local" | "google" | "github";
+  providerId: string;
+  name: string;
+  email: string | undefined;
+  isEmailVerified: boolean;
+  avatar: string | undefined;
+  ip: string;
+  userAgent: string;
+};
+
+export class OAuthService {
+  static async handleOAuthLogin(
+    user: OAuthProfile,
+    context: CookieOptionsType
+  ) {
+    if (!user.email) {
+      throw new Error("Email is required for OAuth login");
+    }
+
+    const [existingUser] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, user.email));
+
+    if (existingUser) {
+      const canAutoLinkProvider =
+        user.isEmailVerified || existingUser.provider === user.provider;
+
+      if (!canAutoLinkProvider) {
+        throw ApiError.forbidden(
+          "Please sign in with your existing provider to link this account."
+        );
+      }
+
+      await db
+        .update(users)
+        .set({
+          provider: user.provider,
+          providerId: user.providerId,
+          isEmailVerified: existingUser.isEmailVerified || user.isEmailVerified,
+          avatar: user.avatar ? { url: user.avatar } : null
+        })
+        .where(eq(users.id, existingUser.id));
+
+      await AuthService.handleToken(
+        {
+          _id: existingUser.id,
+          role: existingUser.role,
+          ip: user.ip,
+          userAgent: user.userAgent
+        },
+        context
+      );
+      return existingUser;
+    }
+
+    const [newUser] = await db
+      .insert(users)
+      .values({
+        name: user.name,
+        email: user.email,
+        isEmailVerified: user.isEmailVerified,
+        provider: user.provider,
+        providerId: user.providerId,
+        avatar: user.avatar ? { url: user.avatar } : null
+      })
+      .$returningId();
+
+    await AuthService.handleToken(
+      {
+        _id: newUser.id,
+        role: "user",
+        ip: user.ip,
+        userAgent: user.userAgent
+      },
+      context
+    );
+
+    return {
+      id: newUser.id,
+      name: user.name,
+      email: user.email,
+      role: "user",
+      avatar: user.avatar ? { url: user.avatar } : null,
+      isEmailVerified: user.isEmailVerified,
+      provider: user.provider,
+      lastLoginAt: new Date()
+    };
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/services/otp.service.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/services/otp.service.ts
@@ -1,0 +1,176 @@
+import { logger } from "../utils/logger";
+import redis from "../configs/redis";
+import {
+  OTP_CODE_LENGTH,
+  OTP_EXPIRES_IN,
+  OTP_MAX_ATTEMPTS,
+  OTP_SPAM_LOCK_TIME,
+  OTP_COOL_DOWN
+} from "../constants/auth";
+import { generateOTP } from "../helpers/token.helpers";
+import { ApiError } from "../utils/api-error";
+import { sendEmail } from "../utils/send-mail";
+
+type SendOtpBase = {
+  name: string;
+  email: string;
+  templateName: string;
+  subject: string;
+};
+
+type SendOtpWithCode = SendOtpBase & {
+  code: string;
+  hashCode: string;
+};
+
+type SendOtpWithoutCode = SendOtpBase & {
+  code?: never;
+  hashCode?: never;
+};
+
+export type SendOtpType = SendOtpWithCode | SendOtpWithoutCode;
+
+export class OtpService {
+  static async checkOtpRestrictions(email: string) {
+    const otpLock = await redis.get(`otp_lock:${email}`);
+    if (otpLock) {
+      throw ApiError.badRequest(
+        "Your Account is locked due to multiple failed attempts. Please try again after 30 minutes."
+      );
+    }
+
+    if (await redis.get(`otp_spam_lock:${email}`)) {
+      throw ApiError.tooManyRequests(
+        "Too many otp requests. Please try again after 1 hour before requesting again."
+      );
+    }
+
+    if (await redis.get(`otp_cooldown:${email}`)) {
+      throw ApiError.tooManyRequests(
+        "Too many otp requests. Please try again after 1 minute before requesting new otp."
+      );
+    }
+  }
+
+  static async trackOtpRequests(email: string) {
+    try {
+      const otpRequestKey = `otp_request_count:${email}`;
+      let otpRequestsCount = parseInt((await redis.get(otpRequestKey)) || "0");
+      if (otpRequestsCount >= OTP_MAX_ATTEMPTS) {
+        await redis.set(`otp_spam_lock:${email}`, "locked", {
+          expiration: {
+            type: "EX",
+            value: 3600
+          }
+        });
+        throw ApiError.tooManyRequests(
+          "Too many otp requests. Please try again after 1 hour before requesting again."
+        );
+      }
+
+      await redis.set(otpRequestKey, otpRequestsCount + 1, {
+        expiration: {
+          type: "EX",
+          value: 3600
+        }
+      });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw ApiError.server("Failed to track otp requests!");
+    }
+  }
+
+  static async sendOtp({
+    name,
+    email,
+    templateName,
+    code,
+    hashCode,
+    subject
+  }: SendOtpType) {
+    try {
+      const newOtp = generateOTP(OTP_CODE_LENGTH);
+      const otpKey = `otp:${email}`;
+      const otpCooldownKey = `otp_cooldown:${email}`;
+      const otpHash = hashCode ? hashCode : newOtp.hashCode;
+
+      logger.info(
+        { email, code: code || newOtp.code },
+        "OTP generated successfully"
+      );
+
+      await redis.set(otpKey, otpHash, {
+        expiration: {
+          type: "EX",
+          value: OTP_EXPIRES_IN / 1000
+        }
+      });
+
+      await redis.set(otpCooldownKey, OTP_COOL_DOWN, {
+        expiration: {
+          type: "EX",
+          value: OTP_COOL_DOWN
+        }
+      });
+
+      try {
+        await sendEmail({
+          email,
+          subject,
+          data: {
+            code: code ? code : newOtp.code,
+            name
+          },
+          templateName
+        });
+      } catch (error) {
+        await Promise.allSettled([
+          redis.del(otpKey),
+          redis.del(otpCooldownKey)
+        ]);
+        throw error;
+      }
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw ApiError.server("Failed to send otp!");
+    }
+  }
+
+  static async verifyOtp(hashCode: string, email: string) {
+    const hashOtpCodeKey = await redis.get(`otp:${email}`);
+
+    if (!hashOtpCodeKey) {
+      throw ApiError.badRequest("Invalid or expired otp");
+    }
+
+    const failedAttemptsKey = `otp_attempts:${email}`;
+    if (hashOtpCodeKey !== hashCode) {
+      const failedAttempts = await redis.incr(failedAttemptsKey);
+
+      if (failedAttempts === 1) {
+        await redis.expire(
+          failedAttemptsKey,
+          Math.floor(OTP_EXPIRES_IN / 1000)
+        );
+      }
+
+      if (failedAttempts >= OTP_MAX_ATTEMPTS) {
+        await redis.set(`otp_lock:${email}`, "locked", {
+          EX: OTP_SPAM_LOCK_TIME
+        });
+        throw ApiError.tooManyRequests(
+          "Too many failed attempts. Please try again after 1 hour."
+        );
+      }
+      throw ApiError.badRequest(
+        `Incorrect OTP. ${OTP_MAX_ATTEMPTS - failedAttempts} attempts left.`
+      );
+    }
+
+    await redis.del([`otp:${email}`, failedAttemptsKey]);
+  }
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/types/user.d.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/types/user.d.ts
@@ -1,0 +1,54 @@
+import { Request } from "express";
+import { OTP_TYPES } from "../constants/auth";
+
+export type OTPType = (typeof OTP_TYPES)[number];
+
+export interface AvatarData {
+  public_id: string;
+  url: string;
+  size: number;
+}
+
+export interface UserRequest extends Request {
+  user?: {
+    id?: string | undefined;
+    role?: "user" | "admin" | undefined;
+    sessionId?: string | undefined;
+  };
+}
+
+export interface IUser {
+  id: string;
+  name: string;
+  email: string;
+  password?: string;
+  role: "user" | "admin";
+  isEmailVerified: boolean;
+  lastLoginAt?: Date;
+  failedLoginAttempts: number;
+  lockUntil?: Date;
+  avatar?: AvatarData | string | null;
+  provider: "local" | "google" | "github";
+  providerId?: string;
+  isDeleted: boolean;
+  deletedAt?: Date;
+  reActivateAvailableAt?: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export type RefreshTokenData = {
+  userId: string;
+  tokenHash: string;
+  expiresAt: Date;
+};
+
+export type SessionData = {
+  userId: string;
+  sessionId: string;
+  refreshTokenHash: string;
+  userAgent: string;
+  ip: string;
+  createdAt: Date;
+  expiresAt: Date;
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/api-error.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/api-error.ts
@@ -1,0 +1,60 @@
+import { STATUS_CODES, StatusCode } from "../constants/status-codes";
+
+export class ApiError extends Error {
+  public readonly statusCode: StatusCode;
+  public readonly isOperational: boolean;
+  public readonly errors?: unknown;
+
+  constructor(
+    statusCode: StatusCode,
+    message: string,
+    errors?: unknown,
+    isOperational = true
+  ) {
+    super(message);
+    this.name = "ApiError";
+    this.statusCode = statusCode;
+    this.errors = errors;
+    this.isOperational = isOperational;
+
+    Error.captureStackTrace(this, this.constructor);
+  }
+
+  static badRequest(message = "Bad Request", errors?: unknown) {
+    return new ApiError(STATUS_CODES.BAD_REQUEST, message, errors);
+  }
+
+  static unauthorized(message = "Unauthorized") {
+    return new ApiError(STATUS_CODES.UNAUTHORIZED, message);
+  }
+
+  static forbidden(message = "Forbidden") {
+    return new ApiError(STATUS_CODES.FORBIDDEN, message);
+  }
+
+  static notFound(message = "Not Found") {
+    return new ApiError(STATUS_CODES.NOT_FOUND, message);
+  }
+
+  static conflict(message = "Conflict") {
+    return new ApiError(STATUS_CODES.CONFLICT, message);
+  }
+
+  static server(message = "Internal Server Error") {
+    return new ApiError(STATUS_CODES.INTERNAL_SERVER_ERROR, message);
+  }
+
+  static unprocessableEntity(message = "Unprocessable Entity") {
+    return new ApiError(STATUS_CODES.UNPROCESSABLE_ENTITY, message);
+  }
+
+  static tooManyRequests(message = "Too Many Requests") {
+    return new ApiError(STATUS_CODES.TOO_MANY_REQUESTS, message);
+  }
+}
+
+/*
+  ? Usage:
+  * throw new ApiError(404, "Not found");
+  * throw ApiError.badRequest("Bad request");
+ */

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/api-response.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/api-response.ts
@@ -1,0 +1,70 @@
+import { STATUS_CODES, StatusCode } from "../constants/status-codes";
+import type { Response } from "express";
+
+type ApiResponseParams<T> = {
+  success: boolean;
+  message: string;
+  statusCode: StatusCode;
+  data?: T | null;
+  errors?: unknown;
+};
+
+export class ApiResponse<T = unknown> {
+  public readonly success: boolean;
+  public readonly message: string;
+  public readonly statusCode: StatusCode;
+  public readonly data?: T | null;
+  public readonly errors?: unknown;
+
+  constructor({
+    success,
+    message,
+    statusCode,
+    data,
+    errors
+  }: ApiResponseParams<T>) {
+    this.success = success;
+    this.message = message;
+    this.statusCode = statusCode;
+    this.data = data;
+    this.errors = errors;
+  }
+
+  send(res: Response): Response {
+    return res.status(this.statusCode).json({
+      success: this.success,
+      message: this.message,
+      statusCode: this.statusCode,
+      ...(this.data !== undefined && { data: this.data }),
+      ...(this.errors !== undefined && { errors: this.errors })
+    });
+  }
+
+  static Success<T>(
+    res: Response,
+    message: string,
+    data?: T,
+    statusCode: StatusCode = STATUS_CODES.OK
+  ): Response {
+    return new ApiResponse<T>({
+      success: true,
+      message,
+      data,
+      statusCode
+    }).send(res);
+  }
+
+  static ok<T>(res: Response, message = "OK", data?: T) {
+    return ApiResponse.Success(res, message, data, STATUS_CODES.OK);
+  }
+
+  static created<T>(res: Response, message = "Created", data?: T) {
+    return ApiResponse.Success(res, message, data, STATUS_CODES.CREATED);
+  }
+}
+
+/*
+ * Usage:
+ * ApiResponse.ok(res, "OK", data);
+ * ApiResponse.created(res, "Created", data);
+ */

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/async-handler.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/async-handler.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from "express";
+
+export type AsyncRouteHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => Promise<unknown>;
+
+export function AsyncHandler(fn: AsyncRouteHandler) {
+  return function (req: Request, res: Response, next: NextFunction) {
+    Promise.resolve()
+      .then(() => fn(req, res, next))
+      .catch(next);
+  };
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/date.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/date.ts
@@ -1,0 +1,22 @@
+export function getRemainingTime(date: Date) {
+  const now = new Date();
+  let diff = date.getTime() - now.getTime();
+
+  if (diff <= 0) {
+    return {
+      days: 0,
+      minutes: 0,
+      seconds: 0
+    };
+  }
+
+  const seconds = Math.floor((diff / 1000) % 60);
+  const minutes = Math.floor((diff / (1000 * 60)) % 60);
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  return {
+    days,
+    minutes,
+    seconds
+  };
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/jwt.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/jwt.ts
@@ -1,0 +1,44 @@
+import jwt from "jsonwebtoken";
+import env from "../configs/env";
+
+const JWT_ACCESS_TOKEN_EXPIRY = "15m";
+const JWT_REFRESH_TOKEN_EXPIRY = "7d";
+
+export function generateAccessToken(user: {
+  _id: string;
+  role: "user" | "admin";
+  sessionId: string;
+}) {
+  return jwt.sign(
+    { _id: user._id, role: user.role, sessionId: user.sessionId },
+    env.JWT_ACCESS_SECRET!,
+    {
+      expiresIn: JWT_ACCESS_TOKEN_EXPIRY
+    }
+  );
+}
+
+export function generateRefreshToken(user: { _id: string; sessionId: string }) {
+  return jwt.sign(
+    { _id: user._id, sessionId: user.sessionId },
+    env.JWT_REFRESH_SECRET!,
+    {
+      expiresIn: JWT_REFRESH_TOKEN_EXPIRY
+    }
+  );
+}
+
+export function verifyAccessToken(token: string) {
+  return jwt.verify(token, env.JWT_ACCESS_SECRET!) as {
+    _id: string;
+    role: "user" | "admin";
+    sessionId: string;
+  };
+}
+
+export function verifyRefreshToken(token: string) {
+  return jwt.verify(token, env.JWT_REFRESH_SECRET!) as {
+    _id: string;
+    sessionId: string;
+  };
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/logger.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/logger.ts
@@ -1,0 +1,17 @@
+import pino from "pino";
+import env from "../configs/env";
+
+export const logger = pino({
+  level: env.LOG_LEVEL,
+  transport:
+    env.NODE_ENV !== "production"
+      ? {
+          target: "pino-pretty",
+          options: {
+            colorize: true,
+            translateTime: "yyyy-mm-dd HH:MM:ss",
+            ignore: "pid,hostname"
+          }
+        }
+      : undefined
+});

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/render-email-template.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/render-email-template.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import ejs from "ejs"; // npm i --save-dev @types/ejs
+import path from "node:path";
+
+export async function renderEmailTemplates(
+  templateName: string,
+  data: Record<string, any>
+) {
+  const templatePath = path.join(
+    process.cwd(),
+    "src",
+    "email-templates",
+    `${templateName}.ejs`
+  );
+  return ejs.renderFile(templatePath, data);
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/send-mail.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import env from "../configs/env";
+import { resend } from "../configs/resend";
+import { renderEmailTemplates } from "./render-email-template";
+
+export type SendMailType = {
+  from?: string;
+  subject: string;
+  data: Record<string, any>;
+  email: string;
+  html?: string;
+  templateName: string;
+};
+
+export async function sendEmail({
+  from,
+  email,
+  subject,
+  data,
+  html,
+  templateName
+}: SendMailType) {
+  const htmlContent =
+    (await renderEmailTemplates(templateName, data)) || html || "";
+
+  return await resend.emails.send({
+    from: from || env.EMAIL_FROM,
+    to: email,
+    subject,
+    replyTo: email,
+    html: htmlContent
+  });
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/shutdown.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/shutdown.ts
@@ -1,0 +1,30 @@
+import { Server } from "http";
+import { logger } from "./logger";
+
+export const configureGracefulShutdown = (server: Server) => {
+  const signals = ["SIGTERM", "SIGINT"];
+
+  signals.forEach(signal => {
+    process.on(signal, () => {
+      logger.info(`\n${signal} signal received. Shutting down gracefully...`);
+
+      server.close(err => {
+        if (err) {
+          logger.error(err, "Error during server close");
+          process.exit(1);
+        }
+
+        logger.info("HTTP server closed.");
+        process.exit(0);
+      });
+
+      // Force shutdown after 10 seconds
+      setTimeout(() => {
+        logger.error(
+          "Could not close connections in time, forcefully shutting down"
+        );
+        process.exit(1);
+      }, 10000);
+    });
+  });
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/validators/auth.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/validators/auth.ts
@@ -1,0 +1,113 @@
+import * as z from "zod";
+import { OTP_TYPES } from "../constants/auth";
+
+export const nameSchema = z
+  .string({ error: "Name must be a string" })
+  .trim()
+  .min(3, {
+    message: "Name must be at least 3 characters long"
+  })
+  .max(50, {
+    message: "Name must be at most 50 characters long"
+  });
+
+export const passwordSchema = z
+  .string({ error: "Password must be a string" })
+  .min(6, {
+    message: "Password must be at least 6 characters long"
+  })
+  .max(80, {
+    message: "Password must be at most 80 characters long"
+  });
+
+export const emailSchema = z
+  .email({ message: "Please enter a valid email address." })
+  .max(100, { message: "Email must be no more than 100 characters." });
+
+export const roleSchema = z
+  .enum(["user", "admin"], {
+    error: "Role must be either applicant, recruiter, or admin"
+  })
+  .default("user");
+
+export const SigninSchema = z.object({
+  email: emailSchema,
+  password: z.string({ error: "Password must be a string" }).min(1, {
+    message: "Password is required"
+  })
+});
+
+export const SignupSchema = z
+  .object({
+    name: nameSchema,
+    email: emailSchema,
+    password: passwordSchema,
+    confirmPassword: passwordSchema,
+    role: roleSchema
+  })
+  .refine(
+    data => {
+      return data.password === data.confirmPassword;
+    },
+    {
+      message: "Passwords do not match",
+      path: ["confirmPassword"]
+    }
+  );
+
+export const RequestOtpSchema = z.object({
+  email: emailSchema,
+  otpType: z.enum(OTP_TYPES, { error: "Invalid otp type" })
+});
+
+export const VerifyOtpSchema = z.object({
+  otpCode: z.string().min(6, "Please enter a valid OTP"),
+  email: emailSchema
+});
+
+export const ResetPasswordSchema = z.object({
+  email: emailSchema,
+  newPassword: passwordSchema
+});
+
+export const ChangePasswordSchema = z.object({
+  oldPassword: z.string({ error: "Password must be a string" }).min(1, {
+    message: "Old password is required"
+  }),
+  newPassword: passwordSchema
+});
+
+export const UpdateProfileSchema = z.object({
+  name: nameSchema.optional(),
+  avatar: z.string().optional()
+});
+
+export const GoogleSigninSchema = z.object({
+  name: nameSchema,
+  email: emailSchema,
+  provider: z.enum(["google", "github"]).default("google"),
+  providerId: z.string({ error: "Provider id must be a string" }).min(1, {
+    message: "Provider id is required"
+  }),
+  avatar: z.string().optional(),
+  isEmailVerified: z.boolean().default(false)
+});
+
+export const DeleteAccountSchema = z.object({
+  userId: z.string({ error: "User id must be a string" }).min(1, {
+    message: "User id is required"
+  }),
+  type: z
+    .enum(["soft", "hard"], { error: "Type must be either soft or hard" })
+    .default("soft")
+});
+
+export type SignupUserType = z.infer<typeof SignupSchema>;
+export type SigninUserType = z.infer<typeof SigninSchema>;
+export type RequestOtpType = z.infer<typeof RequestOtpSchema>;
+export type VerifyOtpType = z.infer<typeof VerifyOtpSchema>;
+export type ResetPasswordType = z.infer<typeof ResetPasswordSchema>;
+export type ChangePasswordType = z.infer<typeof ChangePasswordSchema>;
+export type UpdateProfileType = z.infer<typeof UpdateProfileSchema>;
+export type GoogleSigninType = z.infer<typeof GoogleSigninSchema>;
+export type DeleteAccountType = z.infer<typeof DeleteAccountSchema>;

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/swagger.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/swagger.config.ts
@@ -1,0 +1,16 @@
+import swaggerAutoGen from "swagger-autogen";
+
+const doc = {
+  info: {
+    title: "Hybrid Auth API",
+    description: "Hybrid Auth API",
+    version: "1.0.0"
+  },
+  host: "localhost:9000/api",
+  schemes: ["http"]
+};
+
+const outputFile = "./src/docs/swagger.json";
+const endpointsFiles = ["./src/routes/*.ts"];
+
+swaggerAutoGen(outputFile, endpointsFiles, doc);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/tsconfig.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/drizzle.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/drizzle.config.ts
@@ -3,7 +3,7 @@ import env from "./src/shared/configs/env";
 
 export default defineConfig({
   out: "./src/drizzle/migrations",
-  schema: "./src/drizzle/schemas/*",
+  schema: "./src/drizzle/index.ts",
   dialect: "postgresql",
   dbCredentials: {
     url: env.DATABASE_URL!

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/package.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/package.json
@@ -4,7 +4,7 @@
   "main": "dist/server.js",
   "type": "module",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development npx tsx watch src/server.ts",
+    "dev": "cross-env NODE_ENV=development npx tsx watch --clearScreen=false src/server.ts",
     "build": "rm -rf dist && tsc && tsc-alias",
     "start": "cross-env NODE_ENV=production node dist/server.js",
     "db:generate": "drizzle-kit generate",

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/src/server.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/src/server.ts
@@ -11,11 +11,17 @@ redisClient
   .then(() => {
     logger.info("Redis Connection Success");
     const server = app.listen(port, () => {
-      logger.info(`[server]: Server is running at http://localhost:${port}`);
-      logger.info(`[server]: Environment: ${env.NODE_ENV}`);
+      logger.info("Hybrid Auth API started successfully");
+      logger.info(`URL          : http://localhost:${port}`);
+      logger.info(`Environment  : ${env.NODE_ENV}`);
       logger.info(
-        `[server]: Swagger docs are available at http://localhost:${port}/api/docs`
+        `Version      : ${process.env.npm_package_version ?? "unknown"}`
       );
+      logger.info(`Started At   : ${new Date().toISOString()}`);
+
+      if (env.NODE_ENV !== "production") {
+        logger.info(`API Docs     : http://localhost:${port}/api/docs`);
+      }
     });
 
     configureGracefulShutdown(server);

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/package.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/package.json
@@ -4,7 +4,7 @@
   "main": "dist/server.js",
   "type": "module",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development npx tsx watch src/server.ts",
+    "dev": "cross-env NODE_ENV=development npx tsx watch --clearScreen=false src/server.ts",
     "build": "rm -rf dist && tsc && tsc-alias",
     "start": "cross-env NODE_ENV=production node dist/server.js",
     "db:generate": "drizzle-kit generate",

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/src/server.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/src/server.ts
@@ -11,11 +11,17 @@ redisClient
   .then(() => {
     logger.info("Redis Connection Success");
     const server = app.listen(port, () => {
-      logger.info(`[server]: Server is running at http://localhost:${port}`);
-      logger.info(`[server]: Environment: ${env.NODE_ENV}`);
+      logger.info("Hybrid Auth API started successfully");
+      logger.info(`URL          : http://localhost:${port}`);
+      logger.info(`Environment  : ${env.NODE_ENV}`);
       logger.info(
-        `[server]: Swagger docs are available at http://localhost:${port}/api/docs`
+        `Version      : ${process.env.npm_package_version ?? "unknown"}`
       );
+      logger.info(`Started At   : ${new Date().toISOString()}`);
+
+      if (env.NODE_ENV !== "production") {
+        logger.info(`API Docs     : http://localhost:${port}/api/docs`);
+      }
     });
 
     configureGracefulShutdown(server);


### PR DESCRIPTION
 ### Add hybrid authentication feature with MySQL and Drizzle ORM

- Initialize Node.js + Express + TypeScript feature template
- Integrate MySQL using Drizzle ORM with defined user schema and migrations
- Implement local and OAuth (Google, GitHub, Facebook) hybrid authentication flow
- Add user registration, verification, sign-in, profile management APIs
- Support password management: reset, change, forgot password handling
- Manage user sessions with secure access and refresh tokens
- Enable account deletion, deactivation, and reactivation features
- Configure middleware for security headers, error handling, and logging
- Setup Swagger for API documentation generation
- Add ESLint, Prettier, and commitlint configurations for code quality
- Add Redis connection and graceful shutdown utilities
- Provide README with setup instructions and environment configuration
- Include automated linting and formatting scripts with Husky pre-commit hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full hybrid authentication support, including sign-in, sign-up, password reset, account reactivation, session management, and social login.
  * Added health-check and API documentation endpoints, plus clearer startup details in logs.

* **Bug Fixes**
  * Improved account and session handling to better enforce verification, lockouts, and token refresh behavior.
  * Added safer file upload, email, and error-handling flows for more reliable user actions.

* **Documentation**
  * Added and updated template documentation and API reference material.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->