### PR TITLE
docs(changelog): add hybrid-auth blueprint for Express.js with MySQL

### DIFF
--- a/apps/web/src/app/styles/globals.css
+++ b/apps/web/src/app/styles/globals.css
@@ -5,6 +5,7 @@
 
 @theme inline {
   --color-code: var(--code);
+  --color-drizzle: var(--color-drizzle);
   --color-card-hover: var(--color-card-hover);
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -75,6 +76,7 @@
 
 :root {
   --code: var(--color-neutral-50);
+  --color-drizzle: #89bb14;
   --muted-secondary: #666;
   --color-card-hover: color-mix(in oklab, var(--accent) 50%, transparent);
   --background: #fcfcfc;
@@ -146,6 +148,7 @@
 .dark {
   --code: var(--color-background);
   --muted-secondary: #888;
+  --color-drizzle: #c5f74f;
   --color-card-hover: #ffffff0c;
   --background: #000000;
   --foreground: #ffffff;
@@ -241,11 +244,11 @@
 }
 
 @utility screen-line-before {
-  @apply before:bg-edge relative before:absolute before:top-0 before:-left-[100vw] before:-z-1 before:h-px before:w-[200vw];
+  @apply before:bg-edge relative before:absolute before:top-0 before:left-[-100vw] before:-z-1 before:h-px before:w-[200vw];
 }
 
 @utility screen-line-after {
-  @apply after:bg-edge relative after:absolute after:bottom-0 after:-left-[100vw] after:-z-1 after:h-px after:w-[200vw];
+  @apply after:bg-edge relative after:absolute after:bottom-0 after:left-[-100vw] after:-z-1 after:h-px after:w-[200vw];
 }
 
 @utility primary-ring {

--- a/apps/web/src/components/docs/icons/language-icons.tsx
+++ b/apps/web/src/components/docs/icons/language-icons.tsx
@@ -393,7 +393,7 @@ export const LanguageIcons = {
       viewBox="0 0 18 18">
       <path
         fill="none"
-        stroke="#a6da95"
+        stroke="var(--color-drizzle)"
         strokeLinecap="round"
         strokeLinejoin="round"
         strokeWidth="1.167"
@@ -582,6 +582,9 @@ export function getIconForLanguageExtension(
   }
   if (fileName?.endsWith(".test.ts")) {
     return <LanguageIcons.tstest className="size-4" />;
+  }
+  if (fileName?.startsWith("drizzle.")) {
+    return <LanguageIcons.drizzle className="size-4" />;
   }
   if (
     [

--- a/apps/web/src/content/docs/changelog/index.mdx
+++ b/apps/web/src/content/docs/changelog/index.mdx
@@ -9,6 +9,18 @@ Latest updates and announcements.
 
 ## July 2026
 
+#### 08 July, 2026 - Express.js Hybrid Auth with MySQL(Drizzle) Blueprint
+
+- Added the <Code>hybrid-auth</Code> blueprint for Express.js.
+
+<PackageManagerTabs command="npx servercn-cli@latest add bp hybrid-auth" />
+
+[Read more](/docs/express/blueprints/hybrid-auth-mysql)
+
+<br />
+---
+<br />
+
 #### 02 July, 2026 - Next.js Mongodb(Prisma) Provider
 
 - Added the <Code>mongodb-prisma</Code> provider for Next.js.


### PR DESCRIPTION
- Added new hybrid-auth blueprint for Express.js using MySQL (Drizzle)
- Included CLI command to add the blueprint via servercn-cli
- Provided link to detailed documentation for hybrid-auth blueprint
- Updated changelog for July 8, 2026 entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Drizzle theme color that adapts between light and dark mode.
  * Drizzle-related files now display the matching Drizzle icon automatically.
  * Added a new changelog entry for the Express.js Hybrid Auth with MySQL (Drizzle) blueprint.

* **Style**
  * Updated offscreen pseudo-element positioning syntax for consistent styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->