### PR TITLE
docs(blueprints): fix links and add MySQL hybrid authentication

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -145,8 +145,9 @@
   - [Banking Application with MongoDB (Mongoose)](https://www.servercn.xyz/docs/express/blueprints/banking-app-mongodb)
 
 - [Hybrid Authentication](https://www.servercn.xyz/docs/express/blueprints/hybrid-auth):  ships with credential-based login, OAuth providers, refresh-token rotation, and session management backed by Redis.
-  - pHybrid Authentication with MongoDB (Mongoose)(https://www.servercn.xyz/docs/express/blueprints/hybrid-auth-mongodb)
-  - [Hybrid Authentication with PostgreSQL (Drizzle)](https://www.servercn.xyz/docs/express/blueprints/hybrid-auth-postgresql)
+  - [Hybrid Authentication with MongoDB] (Mongoose)(https://www.servercn.xyz/docs/express/blueprints/hybrid-auth-mongodb)
+  - [Hybrid Authentication with PostgreSQL (Drizzle)](https://www.servercn.xyz/docs/express/blueprints/hybrid-auth-mysql)
+  - [Hybrid Authentication with MySQL (Drizzle)](https://www.servercn.xyz/docs/express/blueprints/hybrid-auth-mysql)
 
 - [Stateful Authentication](https://www.servercn.xyz/docs/express/blueprints/stateful-auth): provides secure user registration, login, session management, and OAuth integration.
   - [Stateful Authentication with MongoDB (Mongoose)](https://www.servercn.xyz/docs/express/blueprints/stateful-auth-mongodb)


### PR DESCRIPTION
- Correct Markdown link syntax for Hybrid Authentication with MongoDB
- Update link for Hybrid Authentication with PostgreSQL to MySQL blueprint
- Add new Hybrid Authentication with MySQL (Drizzle) blueprint link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Express.js Hybrid Authentication links in the public list.
  * Removed an invalid MongoDB entry and replaced outdated PostgreSQL text with updated blueprint links.
  * Added clear options for MongoDB (Mongoose), PostgreSQL, and MySQL variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->