### PR TITLE
refactor: standardize arch naming, fix theme sync, add template configs

### DIFF
--- a/apps/web/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/docs/[[...slug]]/page.tsx
@@ -368,7 +368,7 @@ export default async function DocsPage({
                     from="docs"
                     database={database}
                     orm={orm}
-                    architecture={currentArch}
+                    arch={currentArch}
                     framework={currentFramework || slug[0]}
                     type={
                       ["tooling", ""].includes(slug[1])

--- a/apps/web/src/components/docs/architecture-tabs.tsx
+++ b/apps/web/src/components/docs/architecture-tabs.tsx
@@ -24,12 +24,13 @@ export default function ArchitectureTabs({
   framework,
   className
 }: {
-  current: string;
+  current?: string;
   framework?: FrameworkType;
   className?: string;
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const architecture = (searchParams.get("arch") as ArchType) || current;
 
   // Determine available architectures based on framework
   const availableArchs: ArchType[] = framework
@@ -40,6 +41,7 @@ export default function ArchitectureTabs({
     const params = new URLSearchParams(searchParams.toString());
     params.set("arch", value);
     router.replace(`?${params.toString()}`, { scroll: false });
+    console.log({ architecture, value });
   }
 
   // If only one architecture available, don't show tabs
@@ -65,7 +67,7 @@ export default function ArchitectureTabs({
             onClick={() => onChange(arch)}
             className={cn(
               "hover:bg-card-hover dark:hover:bg-card-hover hover:text-accent-foreground text-muted-primary dark:bg-background bg-background w-full cursor-pointer border-neutral-500/40 px-2 py-2 font-medium shadow-none dark:border-neutral-500/40",
-              current === arch &&
+              architecture === arch &&
                 "bg-card-hover dark:bg-card-hover text-accent-foreground"
             )}>
             {archNaming[arch] || arch.toUpperCase()}

--- a/apps/web/src/components/docs/code-block.tsx
+++ b/apps/web/src/components/docs/code-block.tsx
@@ -27,7 +27,7 @@ export function CodeBlock({
     }
 
     highlight();
-  }, [code, lang]);
+  }, [code, lang, theme.theme]);
 
   return (
     <div

--- a/apps/web/src/components/file-viewer/index.tsx
+++ b/apps/web/src/components/file-viewer/index.tsx
@@ -15,20 +15,21 @@ import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import CopyButton from "@/components/docs/copy-button";
 import { cn } from "@/lib/utils";
 import { getIconForLanguageExtension } from "@/components/docs/icons/language-icons";
-import { ItemType } from "@/@types/registry";
+import { ArchitectureType, ItemType } from "@/@types/registry";
 import Link from "next/link";
 import { Maximize2Icon } from "lucide-react";
 import { Route } from "next";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { useVariant } from "@/store/use-variant";
 import { FileViewerLoader } from "@/components/file-viewer/loader";
+import { useSearchParams } from "next/navigation";
 
 type Props = {
   slug: string;
   runtime?: string;
   framework?: string;
   variant?: string | null;
-  architecture?: string;
+  arch?: string;
   type: ItemType;
   from: "structure" | "docs";
   database?: string;
@@ -40,7 +41,7 @@ export default function ComponentFileViewer({
   slug,
   runtime = "node",
   framework = "express",
-  architecture = "mvc",
+  arch = "mvc",
   from = "docs",
   type = "component",
   database,
@@ -48,6 +49,8 @@ export default function ComponentFileViewer({
   orm,
   variant
 }: Props) {
+  const searchParams = useSearchParams();
+  const architecture = (searchParams.get("arch") as ArchitectureType) || arch;
   const [tree, setTree] = React.useState<FileNode[]>([]);
   const [activeFile, setActiveFile] = React.useState<string>();
   const [selectedFile, setSelectedFile] = React.useState<
@@ -61,6 +64,7 @@ export default function ComponentFileViewer({
   const { theme } = useCodeTheme();
 
   const { variant: Variant } = useVariant();
+  // eslint-disable-next-line react-hooks/immutability
   variant = variant ?? Variant;
 
   const [html, setHtml] = React.useState("");
@@ -101,10 +105,21 @@ export default function ComponentFileViewer({
     }
 
     loadFiles();
-  }, [slug, runtime, framework, architecture, variant]);
+  }, [
+    slug,
+    runtime,
+    framework,
+    architecture,
+    variant,
+    type,
+    database,
+    orm,
+    template
+  ]);
 
   React.useEffect(() => {
     if (!selectedFile?.content) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setHtml("");
       return;
     }
@@ -119,7 +134,7 @@ export default function ComponentFileViewer({
     };
 
     highlight();
-  }, [selectedFile?.content, theme]);
+  }, [selectedFile?.content, selectedFile?.lang, theme]);
 
   function handleSelect(file: FileNode & { type: "file" }) {
     setSelectedFile(file);

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/.gitignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/.prettierignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/.prettierrc
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/tsconfig.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/.gitignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/.prettierignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/.prettierrc
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/tsconfig.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/.gitignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/.prettierignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/.prettierrc
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/tsconfig.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/.gitignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/.prettierignore
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/.prettierrc
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/tsconfig.json
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/.gitignore
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/.prettierignore
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/.prettierrc
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/tsconfig.json
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/.gitignore
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/.prettierignore
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/.prettierrc
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/tsconfig.json
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/.gitignore
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/.prettierignore
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/.prettierrc
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/tsconfig.json
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/feature/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/.gitignore
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/.prettierignore
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/.prettierrc
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/tsconfig.json
+++ b/packages/templates/node/express/blueprint/stateless-auth/mongodb/mongoose/mvc/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/.gitignore
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/.prettierignore
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/.prettierrc
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/tsconfig.json
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/feature/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/.gitignore
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+dist
+build

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/.prettierignore
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/.prettierignore
@@ -1,0 +1,6 @@
+dist
+node_modules
+coverage
+.env
+.env.*
+!.env.example

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/.prettierrc
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": false,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "bracketSameLine": true,
+  "arrowParens": "avoid",
+  "endOfLine": "lf"
+}

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/commitlint.config.ts
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/commitlint.config.ts
@@ -1,0 +1,23 @@
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "style",
+        "refactor",
+        "perf",
+        "test",
+        "build",
+        "ci",
+        "chore",
+        "revert"
+      ]
+    ],
+    "subject-case": [2, "always", "sentence-case"]
+  }
+};

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/eslint.config.mjs
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/eslint.config.mjs
@@ -1,0 +1,31 @@
+import tseslint from "@typescript-eslint/eslint-plugin";
+import tsparser from "@typescript-eslint/parser";
+import prettierPlugin from "eslint-plugin-prettier";
+
+export default [
+  {
+    files: ["**/*.ts"],
+
+    ignores: ["node_modules", "dist", "build", "commitlint.config.ts"],
+
+    languageOptions: {
+      parser: tsparser,
+      sourceType: "module"
+    },
+
+    plugins: {
+      "@typescript-eslint": tseslint,
+      prettier: prettierPlugin
+    },
+
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-unused-expressions": "off",
+      "no-console": "warn",
+      semi: ["error", "always"],
+      quotes: ["error", "double"],
+      "prettier/prettier": "off"
+    }
+  }
+];

--- a/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/tsconfig.json
+++ b/packages/templates/node/express/blueprint/stateless-auth/mysql/drizzle/mvc/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "alwaysStrict": true,
+    "useUnknownInCatchVariables": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "tsc-alias": {
+    "resolveFullPaths": true,
+    "verbose": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
- Standardize prop naming across docs components by renaming `architecture` to `arch` in DocsPage, ArchitectureTabs, and FileViewer
- Fix CodeBlock syntax highlighting not updating when theme changes by adding theme.theme to its useEffect dependency array
- Fix useEffect dependency gaps in FileViewer component to ensure proper re-renders on data changes
- Update ArchitectureTabs to use URL search params for active architecture state, make current prop optional, fix active tab styling, and add a temporary debug log
- Add standard project configuration files (gitignore, prettier config, commitlint config, tsconfig, eslint config) to all Node.js Express auth templates covering hybrid/stateless/stateful auth, various databases and ORMs, and both MVC and feature project structures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation file viewers now support architecture selection through URL parameters and additional template configuration options.
  - Expanded project templates with TypeScript, linting, formatting, commit message, and environment-file configurations across authentication patterns and database setups.

- **Bug Fixes**
  - Documentation tabs now correctly reflect the selected architecture.
  - Code highlighting refreshes when the theme or selected language changes.
  - File content reloads reliably when template settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->