### PR TITLE
Refactor/UI

### DIFF
--- a/apps/web/src/app/(app)/structure/page.tsx
+++ b/apps/web/src/app/(app)/structure/page.tsx
@@ -4,6 +4,7 @@ import CodeTheme from "@/components/docs/code-theme";
 import ComponentFileViewer from "@/components/file-viewer";
 import { Variant } from "@/components/file-viewer/variant";
 import { Container } from "@/components/ui/container";
+import { Suspense } from "react";
 
 export default async function page(props: PageProps<"/components">) {
   const searchParams = await props.searchParams;
@@ -17,20 +18,25 @@ export default async function page(props: PageProps<"/components">) {
           <CodeTheme minimal={true} />
         </div>
 
-        <ArchitectureTabs
-          current={(searchParams?.arch as string) || "mvc"}
-          framework={(searchParams?.framework as FrameworkType) || "express"}
-        />
+        <Suspense fallback={<>...</>}>
+          <ArchitectureTabs
+            current={(searchParams?.arch as string) || "mvc"}
+            framework={(searchParams?.framework as FrameworkType) || "express"}
+          />
+        </Suspense>
+
         <Variant name={(searchParams?.slug as string) || ""} />
-        <ComponentFileViewer
-          from="structure"
-          slug={(searchParams?.slug as string) || ""}
-          arch={(searchParams?.arch as string) || ""}
-          framework={(searchParams?.framework as string) || ""}
-          type={(searchParams?.type as ItemType) || ""}
-          database={(searchParams?.database as string) || undefined}
-          orm={(searchParams?.orm as string) || undefined}
-        />
+        <Suspense fallback={<>...</>}>
+          <ComponentFileViewer
+            from="structure"
+            slug={(searchParams?.slug as string) || ""}
+            arch={(searchParams?.arch as string) || ""}
+            framework={(searchParams?.framework as string) || ""}
+            type={(searchParams?.type as ItemType) || ""}
+            database={(searchParams?.database as string) || undefined}
+            orm={(searchParams?.orm as string) || undefined}
+          />
+        </Suspense>
       </div>
     </Container>
   );

--- a/apps/web/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/docs/[[...slug]]/page.tsx
@@ -30,6 +30,7 @@ import { resolveRegistryItem } from "@/lib/resolver";
 import { cn } from "@/lib/utils";
 import { Variant } from "@/components/file-viewer/variant";
 import { ViewAsJson } from "@/components/docs/view-as-json";
+import { Suspense } from "react";
 
 export const dynamic = "force-static";
 export const dynamicParams = false;
@@ -359,23 +360,27 @@ export default async function DocsPage({
                   <h2 className="mb-2 text-2xl font-semibold tracking-tight">
                     File &amp; Folder Structure
                   </h2>
-                  <ArchitectureTabs
-                    current={currentArch || "mvc"}
-                    framework={currentFramework}
-                  />
-                  <ComponentFileViewer
-                    slug={blueprintSlug ?? slug[slug.length - 1]}
-                    from="docs"
-                    database={database}
-                    orm={orm}
-                    arch={currentArch}
-                    framework={currentFramework || slug[0]}
-                    type={
-                      ["tooling", ""].includes(slug[1])
-                        ? (slug[1] as ItemType)
-                        : (slug[1]?.slice(0, -1) as ItemType)
-                    }
-                  />
+                  <Suspense fallback={<>...</>}>
+                    <ArchitectureTabs
+                      current={currentArch || "mvc"}
+                      framework={currentFramework}
+                    />
+                  </Suspense>
+                  <Suspense fallback={<>...</>}>
+                    <ComponentFileViewer
+                      slug={blueprintSlug ?? slug[slug.length - 1]}
+                      from="docs"
+                      database={database}
+                      orm={orm}
+                      arch={currentArch}
+                      framework={currentFramework || slug[0]}
+                      type={
+                        ["tooling", ""].includes(slug[1])
+                          ? (slug[1] as ItemType)
+                          : (slug[1]?.slice(0, -1) as ItemType)
+                      }
+                    />
+                  </Suspense>
                 </div>
               )}
 

--- a/apps/web/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/docs/[[...slug]]/page.tsx
@@ -6,8 +6,7 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import matter from "gray-matter";
 import { mdxComponents } from "@/components/docs/mdx-components";
 import rehypePrettyCode from "rehype-pretty-code";
-import { cookies } from "next/headers";
-import { COOKIE_THEME_KEY, DEFAULT_CODE_THEME } from "@/lib/constants";
+import { DEFAULT_CODE_THEME } from "@/lib/constants";
 import { OpenInAi } from "@/components/docs/open-in-ai";
 import ArchitectureTabs from "@/components/docs/architecture-tabs";
 import PackageManagerTabs from "@/components/docs/package-manager-tabs";
@@ -241,9 +240,6 @@ export default async function DocsPage({
   const source = fs.readFileSync(filePath, "utf8");
   const { content, data } = matter(source);
 
-  const cookieStore = await cookies();
-  const theme = cookieStore.get(COOKIE_THEME_KEY)?.value ?? DEFAULT_CODE_THEME;
-
   // Extract current framework from URL if present
   const currentFramework =
     slug &&
@@ -337,8 +333,11 @@ export default async function DocsPage({
                     [
                       rehypePrettyCode,
                       {
-                        theme: theme || "vesper",
                         keepBackground: false,
+                        theme: {
+                          dark: DEFAULT_CODE_THEME,
+                          light: "github-light"
+                        },
                         defaultLang: {
                           block: "plaintext",
                           inline: "plaintext"

--- a/apps/web/src/app/styles/globals.css
+++ b/apps/web/src/app/styles/globals.css
@@ -371,7 +371,7 @@
 
   [data-highlighted-line],
   [data-highlighted-chars] {
-    @apply bg-highlight border-muted-foreground relative border-l-2;
+    @apply dark:bg-highlight border-muted-foreground relative border-l-2 bg-neutral-200;
   }
 }
 
@@ -413,4 +413,11 @@ h3 {
 * {
   scrollbar-width: thin;
   scrollbar-color: var(--border) transparent;
+}
+[data-rehype-pretty-code-figure] code span {
+  color: var(--shiki-light);
+}
+
+.dark [data-rehype-pretty-code-figure] code span {
+  color: var(--shiki-dark);
 }

--- a/apps/web/src/components/docs/code-block.tsx
+++ b/apps/web/src/components/docs/code-block.tsx
@@ -15,7 +15,8 @@ export function CodeBlock({
 }) {
   const theme = useCodeTheme();
 
-  const [html, setHtml] = useState("npx servercn-cli@latest init");
+  const [html, setHtml] = useState(code);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function highlight() {
@@ -24,14 +25,30 @@ export function CodeBlock({
         theme: theme.theme || DEFAULT_CODE_THEME
       });
       setHtml(out);
+      setLoading(false);
     }
 
     highlight();
   }, [code, lang, theme.theme]);
 
+  if (loading) {
+    return (
+      <>
+        <pre className="overflow-x-auto overscroll-x-contain p-4">
+          <code
+            data-theme="vesper github-light"
+            data-language="bash"
+            className="font-code leading-none">
+            <span>{code}</span>
+          </code>
+        </pre>{" "}
+      </>
+    );
+  }
+
   return (
     <div
-      className="relative [&_pre]:max-h-80 [&_pre]:max-w-[320px] [&_pre]:overflow-x-auto [&_pre]:rounded-b-md [&_pre]:px-4 [&_pre]:py-4 sm:[&_pre]:max-w-2xl"
+      className="[&_pre]:bg-code! relative [&_pre]:overflow-x-auto [&_pre]:rounded-b-md [&_pre]:px-4 [&_pre]:py-4"
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/apps/web/src/components/docs/code-theme.tsx
+++ b/apps/web/src/components/docs/code-theme.tsx
@@ -22,19 +22,25 @@ import {
   PopoverContent,
   PopoverTrigger
 } from "@/components/ui/popover";
-import { CODE_THEMES } from "@/lib/themes";
+import { DARK_THEMES, LIGHT_THEMES } from "@/lib/themes";
 import { changeCodeBlockBg } from "@/app/actions/theme";
+import { useTheme } from "next-themes";
 
 export { STORAGE_THEME_KEY };
 
 export default function CodeTheme({ minimal = false }: { minimal?: boolean }) {
   const { theme, setTheme } = useCodeTheme();
+  const { theme: nextTheme } = useTheme();
   const { setBg } = useCodeThemeBg();
   const router = useRouter();
   const id = useId();
 
+  const isLight = nextTheme === "light";
+
   const [open, setOpen] = useState<boolean>(false);
   const [mounted, setMounted] = useState(false);
+
+  const themes = isLight ? LIGHT_THEMES : DARK_THEMES;
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -52,11 +58,13 @@ export default function CodeTheme({ minimal = false }: { minimal?: boolean }) {
 
   return (
     <div className="space-y-2">
-      {!minimal && <Label
-        htmlFor={id}
-        className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
-        Code Theme
-      </Label>}
+      {!minimal && (
+        <Label
+          htmlFor={id}
+          className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
+          Code Theme
+        </Label>
+      )}
       <Popover onOpenChange={setOpen} open={open}>
         <PopoverTrigger asChild>
           <Button
@@ -66,8 +74,7 @@ export default function CodeTheme({ minimal = false }: { minimal?: boolean }) {
             role="combobox"
             variant="outline">
             <span className="truncate">
-              {CODE_THEMES.find(t => t.value === theme)?.label ||
-                "Select theme"}
+              {themes.find(t => t.value === theme)?.label || "Select theme"}
             </span>
             <ChevronDownIcon
               aria-hidden="true"
@@ -84,8 +91,9 @@ export default function CodeTheme({ minimal = false }: { minimal?: boolean }) {
             <CommandList>
               <CommandEmpty>No theme found.</CommandEmpty>
               <CommandGroup>
-                {CODE_THEMES.sort((a, b) => a.label.localeCompare(b.label)).map(
-                  t => (
+                {themes
+                  .sort((a, b) => a.label.localeCompare(b.label))
+                  .map(t => (
                     <CommandItem
                       key={t.value}
                       onSelect={() => {
@@ -106,8 +114,7 @@ export default function CodeTheme({ minimal = false }: { minimal?: boolean }) {
                         )}
                       </div>
                     </CommandItem>
-                  )
-                )}
+                  ))}
               </CommandGroup>
             </CommandList>
           </Command>

--- a/apps/web/src/components/docs/package-manager-tabs.tsx
+++ b/apps/web/src/components/docs/package-manager-tabs.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/docs/icons/language-icons";
 import { CodeWrapper } from "@/components/docs/code-wrapper";
 import { usePackageManager } from "@/store/use-package-manager";
+import { CodeBlock } from "./code-block";
 
 const pkgManagers = ["npm", "yarn", "pnpm", "bun"];
 
@@ -49,25 +50,18 @@ export default function PackageManagerTabs({
       {pkgManagers.map(key => {
         const commands = convertNpmCommand(command);
         const cmd = commands[key as PackageManagerType];
-        const [bin, ...rest] = cmd.split(" ");
-        const remaining = rest.join(" ");
         return (
           <TabsContent key={key} value={key} className="border-edge border-t">
             <CodeWrapper code={cmd}>
-              {/* <CodeBlock code={cmd} /> */}
-              <pre className="overflow-x-auto overscroll-x-contain p-4">
+              <CodeBlock code={cmd} />
+              {/* <pre className="overflow-x-auto overscroll-x-contain p-4">
                 <code
-                  data-slot="code-block"
+                  data-theme="vesper github-light"
                   data-language="bash"
                   className="font-code leading-none">
-                  <span className="text-[#eb7520] dark:text-[#ffc799]">
-                    {bin}
-                  </span>{" "}
-                  <span className="text-[#0e99d9] dark:text-[#52e1e3]">
-                    {remaining}
-                  </span>
+                  <span>{cmd}</span>
                 </code>
-              </pre>
+              </pre> */}
             </CodeWrapper>
           </TabsContent>
         );

--- a/apps/web/src/components/docs/pre.tsx
+++ b/apps/web/src/components/docs/pre.tsx
@@ -27,7 +27,10 @@ export function Pre({
       <pre
         ref={ref}
         {...props}
-        className={cn("thin-scrollbar relative", className)}
+        className={cn(
+          "thin-scrollbar text-muted-primary relative",
+          className
+        )}
         style={{
           backgroundColor: "var(--code)"
         }}>

--- a/apps/web/src/components/file-viewer/file-tree.tsx
+++ b/apps/web/src/components/file-viewer/file-tree.tsx
@@ -88,8 +88,9 @@ function TreeNode({
     <button
       onClick={() => onSelect(node)}
       className={cn(
-        "text-muted-foreground hover:bg-muted hover:text-accent-foreground my-1 ml-0.5 flex w-auto cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-left",
-        activeFile === node.path && "bg-muted text-accent-foreground"
+        "text-muted-foreground hover:bg-muted hover:text-accent-foreground ring-edge my-1 ml-0.5 flex w-auto cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-left hover:ring-1",
+        activeFile === node.path &&
+          "bg-muted ring-edge text-accent-foreground ring-1"
       )}>
       {getIconForLanguageExtension(node.lang || "ts", node.name)}
       {node.name}

--- a/apps/web/src/components/file-viewer/file-viewer-depr.tsx
+++ b/apps/web/src/components/file-viewer/file-viewer-depr.tsx
@@ -22,7 +22,7 @@ export default function FileViewer({ content ,lang}: { content?: string ,lang?: 
     };
 
     highlight();
-  }, [content, theme]);
+  }, [content, lang, theme]);
 
   if (!content) {
     return (

--- a/apps/web/src/components/home/hybrid-auth.tsx
+++ b/apps/web/src/components/home/hybrid-auth.tsx
@@ -6,6 +6,7 @@ import { Section } from "@/components/ui/section";
 import { Terminal } from "@/components/ui/terminal";
 import { cn } from "@/lib/utils";
 import ComponentFileViewer from "../file-viewer";
+import { Suspense } from "react";
 export default function HybridAuthSection() {
   return (
     <Section id="hybrid-auth-section" className="">
@@ -53,13 +54,15 @@ export default function HybridAuthSection() {
           />
         </div>
         <div className="col-span-3">
-          <ComponentFileViewer
-            from="structure"
-            slug={"hybrid-auth"}
-            arch={"feature"}
-            framework={"express"}
-            type={"blueprint"}
-          />
+          <Suspense fallback={<>...</>}>
+            <ComponentFileViewer
+              from="structure"
+              slug={"hybrid-auth"}
+              arch={"feature"}
+              framework={"express"}
+              type={"blueprint"}
+            />
+          </Suspense>
         </div>
       </div>
     </Section>

--- a/apps/web/src/components/home/nextjs-starter.tsx
+++ b/apps/web/src/components/home/nextjs-starter.tsx
@@ -6,6 +6,7 @@ import { Section } from "@/components/ui/section";
 import { Terminal } from "@/components/ui/terminal";
 import { cn } from "@/lib/utils";
 import ComponentFileViewer from "@/components/file-viewer";
+import { Suspense } from "react";
 export default function NextjsStarterSection() {
   return (
     <Section id="nextjs-starter-section" className="">
@@ -53,13 +54,15 @@ export default function NextjsStarterSection() {
           />
         </div>
         <div className="col-span-3">
-          <ComponentFileViewer
-            from="structure"
-            slug={"nextjs-starter"}
-            arch={"file-api"}
-            framework={"nextjs"}
-            type={"foundation"}
-          />
+          <Suspense fallback={<>...</>}>
+            <ComponentFileViewer
+              from="structure"
+              slug={"nextjs-starter"}
+              arch={"file-api"}
+              framework={"nextjs"}
+              type={"foundation"}
+            />
+          </Suspense>
         </div>
       </div>
     </Section>

--- a/apps/web/src/components/home/oauth-section.tsx
+++ b/apps/web/src/components/home/oauth-section.tsx
@@ -4,6 +4,7 @@ import { Heading } from "@/components/ui/heading";
 import { SubHeading } from "@/components/ui/sub-heading";
 import { Section } from "@/components/ui/section";
 import ComponentFileViewer from "../file-viewer";
+import { Suspense } from "react";
 export default function OAuthSection() {
   return (
     <Section id="google-oauth-section" className="hidden md:block">
@@ -19,13 +20,15 @@ export default function OAuthSection() {
         <InstallComponentCommands className="col-span-2" />
 
         <div className="col-span-3">
-          <ComponentFileViewer
-            from="structure"
-            slug={"oauth"}
-            arch={"mvc"}
-            framework={"express"}
-            type={"component"}
-          />
+          <Suspense fallback={<>...</>}>
+            <ComponentFileViewer
+              from="structure"
+              slug={"oauth"}
+              arch={"mvc"}
+              framework={"express"}
+              type={"component"}
+            />
+          </Suspense>
         </div>
       </div>
     </Section>

--- a/apps/web/src/content/docs/guides/js-guide.mdx
+++ b/apps/web/src/content/docs/guides/js-guide.mdx
@@ -100,9 +100,7 @@ These scripts handle development, production, type checking, and code formatting
 
 Start the development server by running:
 
-```bash
-npm run dev
-```
+<PackageManagerTabs command="npm run dev" />
 
 Once the server starts successfully, you should see output similar to this:
 
@@ -157,9 +155,7 @@ Now add the component you want.
 
 After adding or updating any component, always run:
 
-```bash
-npm run build
-```
+<PackageManagerTabs command="npm run build" />
 
 This will generate the <Code>dist</Code> folder containing the compiled server files.
 

--- a/apps/web/src/lib/themes.ts
+++ b/apps/web/src/lib/themes.ts
@@ -178,6 +178,8 @@ export const CODE_THEMES: ITheme[] = [
 
 export const LIGHT_THEMES: ITheme[] = CODE_THEMES.filter(t => t.light);
 
+export const DARK_THEMES: ITheme[] = CODE_THEMES.filter(t => !t.light);
+
 export const THEME_PRIMARY_BG = {
   andromeeda: "#23262e",
   "aurora-x": "#07090f",


### PR DESCRIPTION
add suspense fallbacks with simple `<>...</>` text across multiple web app components, including home page sections and docs/structure pages, wrapping async data-fetching components like ComponentFileViewer and ArchitectureTabs to improve loading user experience

- add dedicated DARK_THEMES array split from CODE_THEMES
- overhaul CodeBlock component with loading state and fixed initial value
- fix useEffect dependency array in deprecated file viewer
- update PackageManagerTabs to use CodeBlock for consistent code display
- adjust global CSS to add shiki light/dark code color variables
- simplify docs page theme configuration for rehype-pretty-code
- update file tree component active state styling with ring indicators
- fix minor styling issues across code display components

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added loading states while documentation and file viewers load.
  - Code theme selection now adapts to light and dark mode.
  - Documentation commands now use interactive package-manager tabs.
- **Bug Fixes**
  - Improved syntax highlighting updates when code language changes.
  - Added clearer highlighting and text colors for code blocks.
  - Improved file-tree focus and active-state styling.
- **Style**
  - Refined code block spacing, backgrounds, scrolling, and typography.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->