### PR TITLE
docs(changelog): add hybrid auth starter and update changelog

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -76,6 +76,8 @@
 - [Mongoose Starter](https://www.servercn.xyz/docs/express/foundations/mongoose-starter): database foundation provided by servercn for projects that use MongoDB with Mongoose ODM.
 - [Prisma MongoDB Starter](https://www.servercn.xyz/docs/express/foundations/prisma-mongodb-starter): database foundation provided by servercn for projects that use MongoDB with Prisma ORM.
 - [Prisma MySQL Starter](https://www.servercn.xyz/docs/express/foundations/prisma-mysql-starter): database foundation provided by servercn for projects that use MySQL with Prisma ORM.
+- [Hybrid Authentication  Starter](https://www.servercn.xyz/docs/express/foundations/hybrid-auth): is a production-ready foundation for Express.js applications with modern authentication patterns and best practices. 
+
 
 ### Next.js
 

--- a/apps/web/src/content/docs/changelog/index.mdx
+++ b/apps/web/src/content/docs/changelog/index.mdx
@@ -9,6 +9,28 @@ Latest updates and announcements.
 
 ## July 2026
 
+#### 19 July, 2026 - Express.js Hybrid Auth Foundation
+
+- Added the <Code>hybrid-auth</Code> foundation for Express.js.
+
+#### 1. MongoDB + Mongoose
+
+<PackageManagerTabs command="npx servercn-cli@latest init hybrid-auth --db=mongodb --orm=mongoose" />
+
+#### 2. MySQL + Drizzle
+
+<PackageManagerTabs command="npx servercn-cli@latest init hybrid-auth --db=mysql --orm=drizzle" />
+
+#### 3. PostgreSQL + Drizzle
+
+<PackageManagerTabs command="npx servercn-cli@latest init hybrid-auth --db=postgresql --orm=drizzle" />
+
+[Read more](/docs/express/foundations/hybrid-auth)
+
+<br />
+---
+<br />
+
 #### 08 July, 2026 - Express.js Hybrid Auth with MySQL(Drizzle) Blueprint
 
 - Added the <Code>hybrid-auth</Code> blueprint for Express.js.


### PR DESCRIPTION
Add the Hybrid Authentication Starter entry to the public llms.txt list, and add a new 19 July 2026 changelog entry for the Express.js hybrid auth foundation with setup commands for multiple database and ORM combinations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Hybrid Authentication Starter to the Express.js Foundations documentation.
  * Published a July 2026 changelog entry for the Express.js Hybrid Auth Foundation.
  * Added setup instructions for MongoDB with Mongoose, MySQL with Drizzle, and PostgreSQL with Drizzle.
  * Included a link to additional details for the new foundation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->