### PR TITLE
docs(express): add stateful auth foundation docs

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -76,7 +76,8 @@
 - [Mongoose Starter](https://www.servercn.xyz/docs/express/foundations/mongoose-starter): database foundation provided by servercn for projects that use MongoDB with Mongoose ODM.
 - [Prisma MongoDB Starter](https://www.servercn.xyz/docs/express/foundations/prisma-mongodb-starter): database foundation provided by servercn for projects that use MongoDB with Prisma ORM.
 - [Prisma MySQL Starter](https://www.servercn.xyz/docs/express/foundations/prisma-mysql-starter): database foundation provided by servercn for projects that use MySQL with Prisma ORM.
-- [Hybrid Authentication  Starter](https://www.servercn.xyz/docs/express/foundations/hybrid-auth): is a production-ready foundation for Express.js applications with modern authentication patterns and best practices. 
+- [Hybrid Authentication  Starter](https://www.servercn.xyz/docs/express/foundations/hybrid-auth): is a production-ready hybrid auth foundation for Express.js applications with modern authentication patterns and best practices. 
+- [Stateful Authentication  Starter](https://www.servercn.xyz/docs/express/foundations/stateful-auth): is a production-ready stateful auth foundation for Express.js applications with modern authentication patterns and best practices. 
 
 
 ### Next.js

--- a/apps/web/src/content/docs/changelog/index.mdx
+++ b/apps/web/src/content/docs/changelog/index.mdx
@@ -9,6 +9,20 @@ Latest updates and announcements.
 
 ## July 2026
 
+#### 22 July, 2026 - Express.js Stateful Auth Foundation
+
+- Added the <Code>stateful-auth</Code> foundation for Express.js.
+
+#### 1. MongoDB + Mongoose
+
+<PackageManagerTabs command="npx servercn-cli@latest init stateful-auth --db=mongodb --orm=mongoose" />
+
+[Read more](/docs/express/foundations/stateful-auth)
+
+<br />
+---
+<br />
+
 #### 19 July, 2026 - Express.js Hybrid Auth Foundation
 
 - Added the <Code>hybrid-auth</Code> foundation for Express.js.

--- a/apps/web/src/content/docs/express/foundations/stateful-auth.mdx
+++ b/apps/web/src/content/docs/express/foundations/stateful-auth.mdx
@@ -30,7 +30,7 @@ Manual
 
 #### 1. MongoDB + Mongoose
 
-<PackageManagerTabs command="npx servercn-cli@latest init hybrid-auth --db=mongodb --orm=mongoose" />
+<PackageManagerTabs command="npx servercn-cli@latest init stateful-auth --db=mongodb --orm=mongoose" />
 
 </Steps>
 </TabsContent>


### PR DESCRIPTION
- update the init command snippet in the stateful-auth guide
- add a changelog entry for the new Express stateful auth foundation
- add the stateful auth starter link to llms.txt listings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Express.js Stateful Authentication Foundation with MongoDB and Mongoose support.
  * Added setup instructions and a link to the new foundation in the documentation.
  * Updated the foundations list to include the Stateful Authentication Starter.

* **Bug Fixes**
  * Corrected the initialization command in the stateful authentication setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->