### PR TITLE
feat(express foundations): add stateless auth starter foundation and docs

### DIFF
--- a/apps/web/src/components/docs/code-block.tsx
+++ b/apps/web/src/components/docs/code-block.tsx
@@ -53,7 +53,7 @@ export function CodeBlock({
   return (
     <div
       className={cn(
-        "[&_pre]:bg-code! relative [&_pre]:overflow-x-auto [&_pre]:rounded-b-md [&_pre]:px-4 [&_pre]:py-4",
+        "[&_pre]:bg-code! [&_pre] relative [&_pre]:overflow-x-auto [&_pre]:rounded-b-md [&_pre]:px-4 [&_pre]:py-4",
         className
       )}
       dangerouslySetInnerHTML={{ __html: html }}

--- a/apps/web/src/components/docs/code-wrapper.tsx
+++ b/apps/web/src/components/docs/code-wrapper.tsx
@@ -19,7 +19,7 @@ export function CodeWrapper({
   }
 
   return (
-    <div className="relative rounded-md bg-transparent pr-8">
+    <div className="relative rounded-md bg-transparent pr-12">
       <CopyButton
         handleCopy={copy}
         copied={copied}

--- a/apps/web/src/content/docs/express/components/async-handler.mdx
+++ b/apps/web/src/content/docs/express/components/async-handler.mdx
@@ -7,7 +7,7 @@ command: npx servercn-cli@latest add async-handler
 
 # Async Handler
 
-The <Code>Async Handler</Code> component is a **foundational Express utility** that ensures all errors thrown inside asynchronous route handlers are **reliably captured and forwarded** to Express’s global error middleware.
+The <Code>Async Handler</Code> component is a **foundational Express utility** that ensures all errors thrown inside asynchronous route handlers are **reliably captured and forwarded** to Express's global error middleware.
 
 ---
 

--- a/apps/web/src/content/docs/express/foundations/stateless-auth.mdx
+++ b/apps/web/src/content/docs/express/foundations/stateless-auth.mdx
@@ -1,0 +1,70 @@
+---
+title: Statefu  Auth Starter | Foundation
+description: The Stateless Auth Foundation is the core starting block provided by servercn.
+command: npx servercn-cli init stateless-auth --db=mongodb --orm=mongoose
+---
+
+## Stateless Auth Starter
+
+Stateless Auth Starter is a production-ready foundation for Express.js applications with modern authentication patterns and best practices. 
+
+It provides a production-ready implementation of stateless authentication using Access Tokens, Refresh Tokens, and Token Rotation strategies to ensure high security and scalability.
+
+> This foundation is built using the Stateless Auth blueprint as its base. [Stateless Auth Blueprint](/docs/express/blueprints/stateless-auth)
+
+---
+
+## Installation Guide
+<Tabs defaultValue="command">
+<TabsList>
+<TabsTrigger value="command">
+Command
+</TabsTrigger>
+<TabsTrigger value="manual">
+Manual
+</TabsTrigger>
+</TabsList>
+<TabsContent value="command">
+<Steps>
+<Step>Initialize Stateless Auth with your preferred database setup:</Step>
+
+#### 1. MongoDB + Mongoose
+
+<PackageManagerTabs command="npx servercn-cli@latest init stateless-auth --db=mongodb --orm=mongoose" />
+
+#### 2. MySQL + Drizzle
+
+<PackageManagerTabs command="npx servercn-cli@latest init stateless-auth --db=mysql --orm=drizzle" />
+
+</Steps>
+</TabsContent>
+
+<TabsContent value="manual">
+<Steps>
+<Step>Install the required dependencies:</Step>
+
+#### 1. MongoDB + Mongoose
+<PackageManagerTabs command="npm install express mongoose argon2 cloudinary cookie-parser cors express-rate-limit helmet jsonwebtoken multer nodemailer passport passport-github2 passport-google-oauth20 pino pino-pretty zod dotenv-flow cross-env source-map-support swagger-autogen swagger-ui-express" />
+
+<PackageManagerTabs command="npm install -D @types/express @types/jsonwebtoken @types/bcryptjs @types/cookie-parser @types/cors @types/morgan @types/multer @types/nodemailer @types/passport @types/passport-github2 @types/passport-google-oauth20 morgan @types/source-map-support @types/swagger-ui-express @commitlint/cli @commitlint/config-conventional eslint eslint-plugin-prettier @typescript-eslint/parser @typescript-eslint/eslint-plugin husky lint-staged prettier tsc-alias tsx typescript" />
+
+---
+
+#### 2. MySQL + Drizzle
+<PackageManagerTabs command="npm install express mysql2 ejs node-cron redis drizzle-orm argon2 cloudinary cookie-parser cors express-rate-limit helmet jsonwebtoken multer nodemailer passport passport-github2 passport-google-oauth20 pino pino-pretty zod dotenv-flow cross-env source-map-support swagger-autogen swagger-ui-express" />
+
+<PackageManagerTabs command="npm install -D @types/express drizzle-kit @types/ejs @types/cookie-parser @types/cors @types/jsonwebtoken @types/morgan @types/multer @types/nodemailer @types/passport @types/passport-github2 @types/passport-google-oauth20 morgan @types/source-map-support @types/swagger-ui-express @commitlint/cli @commitlint/config-conventional eslint eslint-plugin-prettier @typescript-eslint/parser @typescript-eslint/eslint-plugin husky lint-staged prettier tsc-alias tsx typescript" />
+
+</Steps>
+</TabsContent>
+</Tabs>
+
+---
+<br />
+ <ComponentFileViewer
+  slug="stateless-auth"
+  from="docs"
+  arch="mvc"
+  framework="express"
+  type="blueprint"
+/>

--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -485,6 +485,18 @@
       }
     },
     {
+      "slug": "stateless-auth",
+      "title": "Stateless Auth Starter",
+      "description": "A production-ready Stateless Auth foundation for Express.js applications with modern authentication patterns and best practices.",
+      "type": "foundation",
+      "status": "stable",
+      "frameworks": ["express"],
+      "docs": "/docs/foundations/stateless-auth",
+      "meta": {
+        "new": true
+      }
+    },
+    {
       "title": "Nextjs Starter",
       "slug": "nextjs-starter",
       "description": "A production-ready Next.js foundation with TypeScript, error handling, and structured logging.",


### PR DESCRIPTION

Add the foundation entry to the registry.json, and create the corresponding documentation page with installation guides for both MongoDB/Mongoose and MySQL/Drizzle setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Stateless Auth Starter foundation for Express, including Access Token, Refresh Token, and token rotation guidance.
  * Added command-based and manual installation instructions for MongoDB/Mongoose and MySQL/Drizzle setups.
  * Added the starter to the foundations registry and marked it as new.

* **Documentation**
  * Improved code block layout and copy-button spacing for readability.
  * Corrected apostrophe formatting in the Async Handler documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->