### PR TITLE
docs: add stateless auth foundation docs entries

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -78,6 +78,7 @@
 - [Prisma MySQL Starter](https://www.servercn.xyz/docs/express/foundations/prisma-mysql-starter): database foundation provided by servercn for projects that use MySQL with Prisma ORM.
 - [Hybrid Authentication  Starter](https://www.servercn.xyz/docs/express/foundations/hybrid-auth): is a production-ready hybrid auth foundation for Express.js applications with modern authentication patterns and best practices. 
 - [Stateful Authentication  Starter](https://www.servercn.xyz/docs/express/foundations/stateful-auth): is a production-ready stateful auth foundation for Express.js applications with modern authentication patterns and best practices. 
+- [Stateless Authentication  Starter](https://www.servercn.xyz/docs/express/foundations/stateless-auth): is a production-ready stateless auth foundation for Express.js applications with modern authentication patterns and best practices. 
 
 
 ### Next.js

--- a/apps/web/src/components/docs/architecture-tabs.tsx
+++ b/apps/web/src/components/docs/architecture-tabs.tsx
@@ -52,7 +52,7 @@ export default function ArchitectureTabs({
   return (
     <div
       className={cn(
-        "bg-background text-muted-primary my-3 w-full max-w-full overflow-auto rounded-md sm:max-w-215",
+        "bg-background text-muted-primary my-3 w-full max-w-full overflow-auto rounded-md sm:max-w-code",
         availableArchs.length === 2 && "border",
         className
       )}>

--- a/apps/web/src/content/docs/changelog/index.mdx
+++ b/apps/web/src/content/docs/changelog/index.mdx
@@ -9,6 +9,22 @@ Latest updates and announcements.
 
 ## July 2026
 
+#### 25 July, 2026 - Express.js Stateless Auth Foundation
+
+- Added the <Code>stateless-auth</Code> foundation for Express.js.
+
+#### 1. MongoDB + Mongoose
+
+<PackageManagerTabs command="npx servercn-cli@latest init stateless-auth --db=mongodb --orm=mongoose" />
+
+<PackageManagerTabs command="npx servercn-cli@latest init stateless-auth --db=mysql --orm=drizzle" />
+
+[Read more](/docs/express/foundations/stateless-auth)
+
+<br />
+---
+<br />
+
 #### 22 July, 2026 - Express.js Stateful Auth Foundation
 
 - Added the <Code>stateful-auth</Code> foundation for Express.js.


### PR DESCRIPTION
Add a new July 25 2026 changelog entry for Express.js stateless auth foundation, and add the corresponding reference to llms.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Stateless Authentication Starter to the Express.js Foundations resources.
  * Added July 2026 changelog content for the Express.js Stateless Auth Foundation, including MongoDB and Mongoose setup guidance.

* **Improvements**
  * Updated architecture documentation tabs for improved responsive layout across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->