### PR TITLE
fix(templates): surface Resend send errors instead of silently succee…

### DIFF
--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/src/shared/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/feature/src/shared/utils/send-mail.ts
@@ -23,11 +23,17 @@ export async function sendEmail({
   const htmlContent =
     (await renderEmailTemplates(templateName, data)) || html || "";
 
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || env.EMAIL_FROM,
     to: email,
     subject,
     replyTo: email,
     html: htmlContent
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/src/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mongodb/mongoose/mvc/src/utils/send-mail.ts
@@ -23,11 +23,17 @@ export async function sendEmail({
   const htmlContent =
     (await renderEmailTemplates(templateName, data)) || html || "";
 
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || env.EMAIL_FROM,
     to: email,
     subject,
     replyTo: email,
     html: htmlContent
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/feature/src/shared/utils/send-mail.ts
@@ -22,11 +22,17 @@ export async function sendEmail({
   const htmlContent =
     (await renderEmailTemplates(templateName, data)) || html || "";
 
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || env.EMAIL_FROM,
     to: email,
     subject,
     replyTo: email,
     html: htmlContent
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/mysql/drizzle/mvc/src/utils/send-mail.ts
@@ -23,11 +23,17 @@ export async function sendEmail({
   const htmlContent =
     (await renderEmailTemplates(templateName, data)) || html || "";
 
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || env.EMAIL_FROM,
     to: email,
     subject,
     replyTo: email,
     html: htmlContent
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/src/shared/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/feature/src/shared/utils/send-mail.ts
@@ -23,11 +23,17 @@ export async function sendEmail({
   const htmlContent =
     (await renderEmailTemplates(templateName, data)) || html || "";
 
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || env.EMAIL_FROM,
     to: email,
     subject,
     replyTo: email,
     html: htmlContent
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/src/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/hybrid-auth/postgresql/drizzle/mvc/src/utils/send-mail.ts
@@ -23,11 +23,17 @@ export async function sendEmail({
   const htmlContent =
     (await renderEmailTemplates(templateName, data)) || html || "";
 
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || env.EMAIL_FROM,
     to: email,
     subject,
     replyTo: email,
     html: htmlContent
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/src/shared/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/feature/src/shared/utils/send-mail.ts
@@ -10,11 +10,17 @@ export type SendMail = {
 };
 
 export async function sendEmail({ from, email, subject, html }: SendMail) {
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || `<${env.EMAIL_FROM}>`,
     to: email,
     subject,
     replyTo: email,
     html
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/src/utils/send-mail.ts
+++ b/packages/templates/node/express/blueprint/stateful-auth/mongodb/mongoose/mvc/src/utils/send-mail.ts
@@ -10,11 +10,17 @@ export type SendMail = {
 };
 
 export async function sendEmail({ from, email, subject, html }: SendMail) {
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || `<${env.EMAIL_FROM}>`,
     to: email,
     subject,
     replyTo: email,
     html
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/component/email-service/resend/feature/src/shared/utils/send-mail.ts
+++ b/packages/templates/node/express/component/email-service/resend/feature/src/shared/utils/send-mail.ts
@@ -10,11 +10,17 @@ type sendMail = {
 };
 
 export async function sendEmail({ from, email, subject, html }: sendMail) {
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || `<${env.EMAIL_FROM}>`,
     to: email,
     subject,
     replyTo: email,
     html
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/express/component/email-service/resend/mvc/src/utils/send-mail.ts
+++ b/packages/templates/node/express/component/email-service/resend/mvc/src/utils/send-mail.ts
@@ -10,11 +10,17 @@ type sendMail = {
 };
 
 export async function sendEmail({ from, email, subject, html }: sendMail) {
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || `<${env.EMAIL_FROM}>`,
     to: email,
     subject,
     replyTo: email,
     html
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }

--- a/packages/templates/node/nextjs/component/email-service/resend/file-api/src/utils/send-mail.ts
+++ b/packages/templates/node/nextjs/component/email-service/resend/file-api/src/utils/send-mail.ts
@@ -10,13 +10,19 @@ type sendMail = {
 };
 
 export async function sendEmail({ from, email, subject, html }: sendMail) {
-  return await resend.emails.send({
+  const response = await resend.emails.send({
     from: from || `<${env.EMAIL_FROM}>`,
     to: email,
     subject,
     replyTo: email,
     html
   });
+
+  if (response.error) {
+    throw new Error(response.error.message || "Failed to send email");
+  }
+
+  return response.data;
 }
 
 /**


### PR DESCRIPTION
## Problem

`sendEmail()` in the Resend templates returns `resend.emails.send()` directly, but the
Resend SDK never throws every failure (non-2xx, unparseable body, network error)
resolves to `{ data: null, error }`. Callers are written against a throwing transport, so
failed sends are treated as successes. In `otp.service.ts` the `catch` that rolls back the
Redis OTP and cooldown keys never runs: the user is told the code was sent, never receives
it, and is locked out by the cooldown.

The nodemailer and mailtrap templates in this repo, with the same `sendEmail` signature and
the same callers, both throw on failure — only the Resend variant swallows it.

## Fix

`sendEmail()` checks `response.error` and throws, matching the other two transports.
Applied to all 11 Resend `send-mail.ts` templates.

## Notes

Found this with [api-doctor](https://github.com/qualtyco/api-doctor), an oxlint plugin for API integration patterns. Happy to remove this note if it's noise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email delivery error handling by reporting failures instead of silently returning unsuccessful results.
  * Standardized successful email responses to return only the relevant delivery data across supported templates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->