### PR TITLE
docs(response-formatter): add nestjs docs

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -10,9 +10,7 @@
 
 > Shadcn ecosystem for Node.js backend
 
-![Servercn Components]('./public/og-image-v2.png')
-
-[Visit website](https://servercn.vercel.app/docs/cli)
+[Visit website](https://servercn.vercel.app/)
 
 [Join discord](https://discord.gg/2fXqnTXF8d)
 

--- a/apps/web/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/docs/[[...slug]]/page.tsx
@@ -6,7 +6,8 @@ import { MDXRemote } from "next-mdx-remote/rsc";
 import matter from "gray-matter";
 import { mdxComponents } from "@/components/docs/mdx-components";
 import rehypePrettyCode from "rehype-pretty-code";
-import { DEFAULT_CODE_THEME } from "@/lib/constants";
+import { cookies } from "next/headers";
+import { COOKIE_THEME_KEY, DEFAULT_CODE_THEME } from "@/lib/constants";
 import { OpenInAi } from "@/components/docs/open-in-ai";
 import ArchitectureTabs from "@/components/docs/architecture-tabs";
 import PackageManagerTabs from "@/components/docs/package-manager-tabs";
@@ -29,106 +30,49 @@ import { resolveRegistryItem } from "@/lib/resolver";
 import { cn } from "@/lib/utils";
 import { Variant } from "@/components/file-viewer/variant";
 import { ViewAsJson } from "@/components/docs/view-as-json";
-import { Suspense } from "react";
 import { FrameworkTabs } from "@/components/docs/select-framework";
 
-export const dynamic = "force-static";
-export const dynamicParams = false;
 export const revalidate = false;
+export const dynamic = "force-dynamic";
+export const dynamicParams = false;
 
-const DOCS_PATH = path.join(
-  /*turbopackIgnore: true*/ process.cwd(),
-  "src",
-  "content",
-  "docs"
-);
+const DOCS_PATH = path.join(process.cwd(), "src/content/docs");
 
 export async function generateStaticParams() {
   const registryParams = registry.items.flatMap(({ meta, docs }) => {
+    const nestedSlugs =
+      meta && (meta.databases || [])
+        ? (meta.databases || []).map(({ slug }) => slug)
+        : [];
     const slugArray = docs.replace("/docs/", "").split("/").filter(Boolean);
+    const baseParams = [...slugArray, ...nestedSlugs];
 
-    const params = [
-      {
-        slug: slugArray
-      }
-    ];
-
-    const FRAMEWORK_SUPPORT_SECTIONS = ["schemas", "blueprints"];
-
-    const databaseParams = (meta?.databases ?? []).flatMap(({ slug }) => [
-      {
-        slug: [...slugArray, slug]
-      },
-      {
-        slug: [slugArray[0], slug]
-      }
-    ]);
-
-    params.push(...databaseParams);
-
+    // Generate framework variants for framework-based sections
     const section = slugArray[0];
-
-    if (
-      FRAMEWORK_SECTIONS.includes(section) ||
-      FRAMEWORK_SUPPORT_SECTIONS.includes(section)
-    ) {
-      params.push(
-        {
-          slug: ["express", ...slugArray]
-        },
-        {
-          slug: ["nestjs", ...slugArray]
-        },
-        {
-          slug: ["nextjs", ...slugArray]
-        }
-      );
+    if (FRAMEWORK_SECTIONS.includes(section)) {
+      return [
+        baseParams,
+        ["express", ...baseParams],
+        ["nestjs", ...baseParams]
+      ];
     }
 
-    const databaseFrameworkParams = (meta?.databases ?? []).flatMap(
-      ({ slug }) => [
-        {
-          slug: ["express", slugArray[0], slug]
-        },
-        {
-          slug: ["nestjs", slugArray[0], slug]
-        },
-        {
-          slug: ["nextjs", slugArray[0], slug]
-        }
-      ]
-    );
-
-    params.push(...databaseFrameworkParams);
-
-    return params;
+    return [baseParams];
   });
 
-  const contributingParams = contributingGuides.map(({ docs }) => ({
-    slug: docs.replace("/docs/", "").split("/").filter(Boolean)
-  }));
+  const contributingParams = contributingGuides.map(({ docs }) => {
+    const slugArray = docs.replace("/docs/", "").split("/").filter(Boolean);
+    return slugArray;
+  });
 
   const specialRoutes = [
     { slug: [] },
     { slug: ["introduction"] },
     { slug: ["cli"] },
-    { slug: ["installation"] },
-    { slug: ["changelog"] }
+    { slug: ["installation"] }
   ];
 
-  const changelogPaths = fs
-    .readdirSync(path.join(DOCS_PATH, "changelog"))
-    .filter(file => file.endsWith(".mdx") && file !== "index.mdx")
-    .map(file => ({
-      slug: ["changelog", file.replace(".mdx", "")]
-    }));
-
-  return [
-    ...specialRoutes,
-    ...registryParams,
-    ...contributingParams,
-    ...changelogPaths
-  ];
+  return [...specialRoutes, ...registryParams, ...contributingParams];
 }
 
 export async function generateMetadata(props: {
@@ -182,24 +126,24 @@ export async function generateMetadata(props: {
   };
 }
 
-function getDocPath(slug: string[] = []) {
-  const actualSlug = slug.filter(Boolean);
-  if (actualSlug.length === 0 || actualSlug[0] === "introduction") {
+function getDocPath(slug?: string[]) {
+  if (!slug || slug.length === 0 || slug[0] === "introduction") {
     return path.join(DOCS_PATH, "guides", "getting-started.mdx");
-  }
-
-  if (actualSlug.length === 1 && actualSlug[0] === "installation") {
+  } else if (slug.length === 1 && slug[0] === "installation") {
     return path.join(DOCS_PATH, "guides", "installation.mdx");
   }
 
-  if (actualSlug[0] === "changelog") {
-    return actualSlug.length === 1
-      ? path.join(DOCS_PATH, "changelog", "index.mdx")
-      : path.join(DOCS_PATH, `${actualSlug.join("/")}.mdx`);
+  const actualSlug = slug;
+
+  if (actualSlug.length === 2 && actualSlug[0] === "contributing") {
+    return path.join(DOCS_PATH, `${actualSlug.join("/")}.mdx`);
   }
 
-  const regPath = path.join(DOCS_PATH, `${actualSlug.join("/")}.mdx`);
-  return regPath;
+  if (actualSlug.length === 2 && actualSlug[0] === "schemas") {
+    return path.join(DOCS_PATH, `${actualSlug.join("/")}.mdx`);
+  }
+
+  return path.join(DOCS_PATH, `${actualSlug.join("/")}.mdx`);
 }
 
 export default async function DocsPage({
@@ -241,6 +185,9 @@ export default async function DocsPage({
   const source = fs.readFileSync(filePath, "utf8");
   const { content, data } = matter(source);
 
+  const cookieStore = await cookies();
+  const theme = cookieStore.get(COOKIE_THEME_KEY)?.value ?? DEFAULT_CODE_THEME;
+
   // Extract current framework from URL if present
   const currentFramework =
     slug &&
@@ -254,6 +201,7 @@ export default async function DocsPage({
     orm
     // variant
   } = resolveRegistryItem(slug[slug.length - 1]);
+
 
   return (
     <>
@@ -269,8 +217,7 @@ export default async function DocsPage({
                   "guides",
                   "installation",
                   "introduction",
-                  "contributing",
-                  "changelog"
+                  "contributing"
                 ].includes(slug[0]) && (
                   <ViewAsJson
                     type={
@@ -283,42 +230,39 @@ export default async function DocsPage({
                 )}
               </div>
               <div className="flex items-center gap-2">
-                {/* <ShareMenu
-                  title={data.title}
-                  url={`/docs/${currentFramework}/${
-                    ["tooling"].includes(slug[0])
-                      ? (slug[0] as ItemType)
-                      : (slug[1] as ItemType)
-                  }/${blueprintSlug}`}
-                /> */}
-                <div className="flex items-center gap-2">
-                  <Link
-                    className={cn(buttonVariants({ variant: "secondary" }))}
-                    href={
-                      (prev
-                        ? injectFramework(
-                            prev.docs as string,
-                            currentFramework || ""
-                          )
-                        : "") as Route
-                    }>
-                    <ArrowLeftIcon className="size-4" />
-                  </Link>
-                  <Link
-                    href={
-                      (next
-                        ? injectFramework(
-                            next.docs as string,
-                            currentFramework || ""
-                          )
-                        : "") as Route
-                    }
-                    className={cn(buttonVariants({ variant: "secondary" }))}>
-                    <ArrowRightIcon className="size-4" />
-                  </Link>
-                </div>
+                <Link
+                  className={cn(
+                    buttonVariants({ variant: "outline" }),
+                    "primary-ring"
+                  )}
+                  href={
+                    (prev
+                      ? injectFramework(
+                          prev.docs as string,
+                          currentFramework || ""
+                        )
+                      : "") as Route
+                  }>
+                  <ArrowLeftIcon className="size-4" />
+                </Link>
+                <Link
+                  href={
+                    (next
+                      ? injectFramework(
+                          next.docs as string,
+                          currentFramework || ""
+                        )
+                      : "") as Route
+                  }
+                  className={cn(
+                    buttonVariants({ variant: "outline" }),
+                    "primary-ring"
+                  )}>
+                  <ArrowRightIcon className="size-4" />
+                </Link>
               </div>
             </div>
+
             <div className="space-y-4">
               <h1 className="text-3xl font-medium tracking-tight">
                 {data.title}
@@ -326,7 +270,7 @@ export default async function DocsPage({
               <p className="text-muted-foreground">{data.description}</p>
             </div>
 
-            <div className="border-b mt-4 pb-5">
+            <div className="mt-4 border-b pb-5">
               <FrameworkTabs />
             </div>
             <MDXRemote
@@ -338,11 +282,8 @@ export default async function DocsPage({
                     [
                       rehypePrettyCode,
                       {
+                        theme: theme || "vesper",
                         keepBackground: false,
-                        theme: {
-                          dark: DEFAULT_CODE_THEME,
-                          light: "github-light"
-                        },
                         defaultLang: {
                           block: "plaintext",
                           inline: "plaintext"
@@ -364,27 +305,23 @@ export default async function DocsPage({
                   <h2 className="mb-2 text-2xl font-semibold tracking-tight">
                     File &amp; Folder Structure
                   </h2>
-                  <Suspense fallback={<>...</>}>
-                    <ArchitectureTabs
-                      current={currentArch || "mvc"}
-                      framework={currentFramework}
-                    />
-                  </Suspense>
-                  <Suspense fallback={<>...</>}>
-                    <ComponentFileViewer
-                      slug={blueprintSlug ?? slug[slug.length - 1]}
-                      from="docs"
-                      database={database}
-                      orm={orm}
-                      arch={currentArch}
-                      framework={currentFramework || slug[0]}
-                      type={
-                        ["tooling", ""].includes(slug[1])
-                          ? (slug[1] as ItemType)
-                          : (slug[1]?.slice(0, -1) as ItemType)
-                      }
-                    />
-                  </Suspense>
+                  <ArchitectureTabs
+                    current={currentArch || "mvc"}
+                    framework={currentFramework}
+                  />
+                  <ComponentFileViewer
+                    slug={blueprintSlug ?? slug[slug.length - 1]}
+                    from="docs"
+                    database={database}
+                    orm={orm}
+                    arch={currentArch}
+                    framework={currentFramework || slug[0]}
+                    type={
+                      ["tooling", ""].includes(slug[1])
+                        ? (slug[1] as ItemType)
+                        : (slug[1]?.slice(0, -1) as ItemType)
+                    }
+                  />
                 </div>
               )}
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -66,7 +66,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className={fontVariables}>
+    <html
+      data-scroll-behavior="smooth"
+      lang="en"
+      suppressHydrationWarning
+      className={fontVariables}>
       <body
         className={`selection:bg-primary selection:text-primary-foreground scroll-pt-10 scroll-smooth antialiased`}>
         <ThemeProvider

--- a/apps/web/src/components/docs/select-framework.tsx
+++ b/apps/web/src/components/docs/select-framework.tsx
@@ -206,7 +206,7 @@ export function FrameworkTabs({
 
   return (
     <div className="border-border relative flex w-full items-center justify-between gap-10">
-      <div className="flex gap-8">
+      <div className="flex gap-4 sm:gap-8">
         {FRAMEWORK_OPTIONS.map(({ value, label }) => {
           const isActive = displayValue === value;
 
@@ -217,7 +217,7 @@ export function FrameworkTabs({
               onClick={() => handleChange(value)}
               className={cn(
                 "relative flex cursor-pointer items-center gap-2 py-2 text-base font-medium outline-none sm:text-lg",
-                value === "nestjs" && "pointer-events-none"
+                // value === "nestjs" && "pointer-events-none"
               )}>
               <span
                 className={cn(

--- a/apps/web/src/components/home/supported-frameworks.tsx
+++ b/apps/web/src/components/home/supported-frameworks.tsx
@@ -43,7 +43,7 @@ const FRAMEWORKS: Framework[] = [
   {
     name: "NestJS",
     icon: SiNestjs,
-    status: "coming-soon",
+    status: "working",
     description:
       "Enterprise-grade Node.js. Modular components for guards, interceptors, pipes — aligned with NestJS DI patterns.",
     frameworks: ["nestjs"],
@@ -52,7 +52,7 @@ const FRAMEWORKS: Framework[] = [
   {
     name: "Next.js",
     icon: SiNextdotjs,
-    status: "working",
+    status: "available",
     description:
       "Full-stack ready. Route handlers, server actions, and middleware components for Next.js App Router backends",
     frameworks: ["nextjs"],

--- a/apps/web/src/components/layouts/docs-sidebar.tsx
+++ b/apps/web/src/components/layouts/docs-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   ChevronDown
 } from "lucide-react";
 import { useState } from "react";
+import { SelectFramework } from "../docs/select-framework";
 
 export const ITEM_GROUP_NAMING = {
   guide: "Getting Started",
@@ -154,6 +155,7 @@ export default function DocsSidebar({
   return (
     <nav className="no-scrollbar font-inter sticky top-20 left-0 z-10 h-full max-h-[calc(100vh-2rem)] space-y-4 overflow-y-auto px-3 py-0 pb-14 text-sm lg:mb-10">
       <CodeTheme />
+      <SelectFramework />
 
       <div className="mt-6 space-y-5">
         {navSections.map(section => {

--- a/apps/web/src/content/docs/nestjs/components/response-formatter.mdx
+++ b/apps/web/src/content/docs/nestjs/components/response-formatter.mdx
@@ -1,0 +1,572 @@
+---
+title: API Response Formatter
+description: Response Formatter provides a consistent, type-safe response structure for NestJS APIs.
+
+command: npx servercn-cli@latest add response-formatter
+---
+
+## Installation Guide
+
+<Tabs defaultValue="command">
+<TabsList>
+<TabsTrigger value="command">
+Command
+</TabsTrigger>
+<TabsTrigger value="manual">
+Manual
+</TabsTrigger>
+</TabsList>
+<TabsContent value="command">
+
+<Steps>
+<Step>Run the following command:</Step>
+<PackageManagerTabs command="npx servercn-cli@latest add response-formatter" />
+
+<Step>Register the interceptor and filter</Step>
+
+Register the interceptor and exception filter globally in your root module or bootstrap file.
+
+##### Option 1: Global Setup (Recommended)
+
+```ts title="src/main.ts" {11-13, 3-6}
+import { NestFactory, Reflector } from '@nestjs/core';
+import { AppModule } from './app.module';
+import {
+  ResponseExceptionFilter,
+  ResponseInterceptor,
+} from './shared/response';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  const reflector = app.get(Reflector);
+  app.useGlobalInterceptors(new ResponseInterceptor(reflector));
+  app.useGlobalFilters(new ResponseExceptionFilter());
+
+  await app.listen(process.env.PORT ?? 8000);
+}
+void bootstrap();
+```
+
+##### Option 2: Per-Module Setup
+```ts title="src/users/users.controller.ts" {3-6, 9-10}
+import { Controller, UseFilters, UseInterceptors } from '@nestjs/common';
+
+import {
+  ResponseExceptionFilter,
+  ResponseInterceptor,
+} from '@/shared/response';
+
+@Controller('users')
+@UseInterceptors(ResponseInterceptor)
+@UseFilters(ResponseExceptionFilter)
+export class UsersController {}
+```
+
+</Steps>
+</TabsContent>
+<TabsContent value="manual">
+
+<Steps>
+
+<Step>Response types</Step>
+
+The shared shape of every response, plus the pagination contract:
+
+```ts title="src/shared/response/response.types.ts"
+import { HttpStatus } from "@nestjs/common";
+
+export type PaginationMeta = {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+};
+
+export type ApiResponseOptions<T = unknown> = {
+  success: boolean;
+  message: string;
+  statusCode: HttpStatus;
+  data?: T | null;
+  errors?: unknown;
+  meta?: PaginationMeta | Record<string, unknown>;
+};
+
+export type SuccessResponse<T = unknown> = {
+  success: true;
+  message: string;
+  statusCode: HttpStatus;
+  data?: T | null;
+  meta?: PaginationMeta | Record<string, unknown>;
+};
+
+export type ErrorResponse = {
+  success: false;
+  message: string;
+  statusCode: HttpStatus;
+  errors?: unknown;
+};
+```
+
+<Step>ApiResponse builder</Step>
+
+The envelope itself, with static helpers for the common status codes:
+
+```ts title="src/shared/response/api-response.ts"
+import { HttpStatus } from "@nestjs/common";
+import type {
+  ApiResponseOptions,
+  ErrorResponse,
+  SuccessResponse
+} from "./response.types";
+
+export class ApiResponse<T = unknown> {
+  public readonly success: boolean;
+  public readonly message: string;
+  public readonly statusCode: HttpStatus;
+  public readonly data?: T | null;
+  public readonly errors?: unknown;
+  public readonly meta?: ApiResponseOptions<T>["meta"];
+
+  constructor(options: ApiResponseOptions<T>) {
+    this.success = options.success;
+    this.message = options.message;
+    this.statusCode = options.statusCode;
+    this.data = options.data;
+    this.errors = options.errors;
+    this.meta = options.meta;
+  }
+
+  static success<T = unknown>(
+    message: string,
+    data?: T | null,
+    statusCode = HttpStatus.OK,
+    meta?: ApiResponseOptions<T>["meta"]
+  ): ApiResponse<T> {
+    return new ApiResponse<T>({
+      success: true,
+      message,
+      statusCode,
+      data,
+      meta
+    });
+  }
+
+  static ok<T = unknown>(
+    message = "OK",
+    data?: T | null,
+    meta?: ApiResponseOptions<T>["meta"]
+  ): ApiResponse<T> {
+    return ApiResponse.success(message, data, HttpStatus.OK, meta);
+  }
+
+  static created<T = unknown>(
+    message = "Created",
+    data?: T | null
+  ): ApiResponse<T> {
+    return ApiResponse.success(message, data, HttpStatus.CREATED);
+  }
+
+  static accepted<T = unknown>(
+    message = "Accepted",
+    data?: T | null
+  ): ApiResponse<T> {
+    return ApiResponse.success(message, data, HttpStatus.ACCEPTED);
+  }
+
+  static error(
+    message: string,
+    statusCode: HttpStatus,
+    errors?: unknown
+  ): ApiResponse<never> {
+    return new ApiResponse<never>({
+      success: false,
+      message,
+      statusCode,
+      errors
+    });
+  }
+
+  toJSON(): SuccessResponse<T> | ErrorResponse {
+    return {
+      success: this.success,
+      message: this.message,
+      statusCode: this.statusCode,
+      ...(this.data !== undefined && {
+        data: this.data
+      }),
+      ...(this.meta !== undefined && {
+        meta: this.meta
+      }),
+      ...(this.errors !== undefined && {
+        errors: this.errors
+      })
+    };
+  }
+}
+```
+
+<Step>Response decorator</Step>
+
+Lets a route or a whole controller declare its success message as metadata:
+
+```ts title="src/shared/response/response.decorator.ts"
+import { SetMetadata } from "@nestjs/common";
+
+export const RESPONSE_OPTIONS_KEY = Symbol("response_options");
+
+export type ResponseOptions = {
+  message?: string;
+};
+
+export const ApiResponseConfig = (options: ResponseOptions = {}) =>
+  SetMetadata(RESPONSE_OPTIONS_KEY, options);
+```
+
+<Step>Response interceptor</Step>
+
+Wraps whatever a handler returns, unless it already returned an <Code>ApiResponse</Code>:
+
+```ts title="src/shared/response/response.interceptor.ts"
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor
+} from "@nestjs/common";
+
+import { Reflector } from "@nestjs/core";
+
+import { Observable, map } from "rxjs";
+
+import { ApiResponse } from "./api-response";
+import { RESPONSE_OPTIONS_KEY, ResponseOptions } from "./response.decorator";
+import { Response } from "express";
+
+@Injectable()
+export class ResponseInterceptor<T> implements NestInterceptor<
+  T,
+  ApiResponse<T>
+> {
+  constructor(private readonly reflector: Reflector) {}
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<T>
+  ): Observable<ApiResponse<T>> {
+    const response = context.switchToHttp().getResponse<Response>();
+
+    const statusCode = response.statusCode;
+
+    const options = this.reflector.getAllAndOverride<ResponseOptions>(
+      RESPONSE_OPTIONS_KEY,
+      [context.getHandler(), context.getClass()]
+    );
+
+    const message = options?.message ?? "Request successful";
+
+    return next.handle().pipe(
+      map(data => {
+        if (data instanceof ApiResponse) {
+          return data;
+        }
+
+        return new ApiResponse<T>({
+          success: true,
+          statusCode: statusCode,
+          message,
+          data
+        });
+      })
+    );
+  }
+}
+```
+
+<Step>Exception filter</Step>
+
+Catches everything thrown anywhere in the app and returns the same envelope:
+
+```ts title="src/shared/response/response.filter.ts"
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException
+} from "@nestjs/common";
+
+import type { Response } from "express";
+
+import { HttpStatus } from "@nestjs/common";
+
+import { ApiResponse } from "./api-response";
+
+@Catch()
+export class ResponseExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const response = host.switchToHttp().getResponse<Response>();
+
+    let statusCode: HttpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+
+    let message = "Internal server error";
+    let errors: unknown;
+
+    if (exception instanceof HttpException) {
+      statusCode = exception.getStatus();
+
+      const exceptionResponse = exception.getResponse();
+
+      if (typeof exceptionResponse === "string") {
+        message = exceptionResponse;
+      } else if (
+        typeof exceptionResponse === "object" &&
+        exceptionResponse !== null
+      ) {
+        const errorResponse = exceptionResponse as Record<string, unknown>;
+
+        if (typeof errorResponse.message === "string") {
+          message = errorResponse.message;
+        }
+
+        errors = errorResponse;
+      }
+    }
+
+    const apiResponse = ApiResponse.error(message, statusCode, errors);
+
+    response.status(statusCode).json(apiResponse);
+  }
+}
+```
+
+<Step>Barrel file</Step>
+
+```ts title="src/shared/response/index.ts"
+export * from "./api-response";
+export * from "./response.decorator";
+export * from "./response.interceptor";
+export * from "./response.filter";
+export * from "./response.types";
+```
+<Step>Register the interceptor and filter</Step>
+
+Register the interceptor and exception filter globally in your root module or bootstrap file.
+
+##### Option 1: Global Setup (Recommended)
+
+```ts title="src/main.ts" {11-13, 3-6}
+import { NestFactory, Reflector } from '@nestjs/core';
+import { AppModule } from './app.module';
+import {
+  ResponseExceptionFilter,
+  ResponseInterceptor,
+} from './shared/response';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+
+  const reflector = app.get(Reflector);
+  app.useGlobalInterceptors(new ResponseInterceptor(reflector));
+  app.useGlobalFilters(new ResponseExceptionFilter());
+
+  await app.listen(process.env.PORT ?? 8000);
+}
+void bootstrap();
+```
+
+##### Option 2: Per-Module Setup
+```ts title="src/users/users.controller.ts" {3-6, 9-10}
+import { Controller, UseFilters, UseInterceptors } from '@nestjs/common';
+
+import {
+  ResponseExceptionFilter,
+  ResponseInterceptor,
+} from '@/shared/response';
+
+@Controller('users')
+@UseInterceptors(ResponseInterceptor)
+@UseFilters(ResponseExceptionFilter)
+export class UsersController {}
+```
+
+</Steps>
+</TabsContent>
+</Tabs>
+
+---
+
+## Usage Examples
+
+### 1. Basic Success Response
+Return data directly from your controller — the interceptor handles wrapping:
+
+```ts title="src/health/health.controller.ts"
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  check() {
+    return { status: 'up', timestamp: new Date().toISOString() };
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Request successful",
+  "statusCode": 200,
+  "data": {
+    "status": "up",
+    "timestamp": "2026-08-28T03:16:19.757Z"
+  }
+}
+```
+
+### 2. Custom Message with Decorator
+
+```ts title="src/users/users.controller.ts" {3, 8-10}
+import { Controller, Get, Param } from '@nestjs/common';
+
+import { ApiResponseConfig } from '@/shared/response';
+
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  @ApiResponseConfig({
+    message: 'User found successfully',
+  })
+  findOne(@Param('id') id: string) {
+    return { id, name: 'John Doe', email: 'john@example.com' };
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "User found successfully",
+  "statusCode": 200,
+  "data": {
+    "id": "123",
+    "name": "John Doe",
+    "email": "john@example.com"
+  }
+}
+```
+
+### 3. Manual ApiResponse (Bypass Interceptor)
+Return an ApiResponse instance directly to skip automatic wrapping:
+
+```ts title="src/users/users.controller.ts" {2, 15}
+import { Controller, Post } from '@nestjs/common';
+import { ApiResponse } from '@/shared/response';
+
+@Controller('users')
+export class UsersController {
+  @Post()
+  create() {
+    const user = {
+      id: 'usr_123',
+      name: 'John Doe',
+      username: 'john_doe',
+      email: 'john@example.com',
+    };
+
+    return ApiResponse.created('User created successfully', user);
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "User created successfully",
+  "statusCode": 201,
+  "data": {
+    "id": "usr_123",
+    "name": "John Doe",
+    "username": "john_doe",
+    "email": "john@example.com"
+  }
+}
+```
+
+### 4. Error Handling
+Throw standard NestJS exceptions — the filter handles formatting:
+
+```ts title="src/users/users.controller.ts" {7}
+import { BadRequestException, Controller, Get, Param } from '@nestjs/common';
+
+@Controller('users')
+export class UsersController {
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    throw new BadRequestException('Invalid User ID');
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": false,
+  "message": "Invalid User ID",
+  "statusCode": 400,
+  "errors": {
+    "message": "Invalid User ID",
+    "error": "Bad Request",
+    "statusCode": 400
+  }
+}
+```
+
+### 5. Pagination with Meta
+
+```ts title="src/posts/posts.controller.ts"
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiResponse, PaginationMeta } from '@/src/shared/response';
+
+@Controller('posts')
+export class PostsController {
+  @Get()
+  findAll(@Query('page') page = 1, @Query('limit') limit = 10) {
+    const { data, total } = this.postsService.paginate(page, limit);
+    
+    const meta: PaginationMeta = {
+      page: Number(page),
+      limit: Number(limit),
+      total,
+      totalPages: Math.ceil(total / limit),
+      hasNextPage: page * limit < total,
+      hasPreviousPage: page > 1,
+    };
+    
+    return ApiResponse.ok('Posts retrieved', data, meta);
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Posts retrieved",
+  "statusCode": 200,
+  "data": [...],
+  "meta": {
+    "page": 1,
+    "limit": 10,
+    "total": 45,
+    "totalPages": 5,
+    "hasNextPage": true,
+    "hasPreviousPage": false
+  }
+}
+```

--- a/apps/web/src/content/docs/nextjs/components/response-formatter.mdx
+++ b/apps/web/src/content/docs/nextjs/components/response-formatter.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Response Formatter
-description: A standardized response formatter for Next.js Route Handlers that ensures consistent API responses across your application.
+description: A standardized response formatter for Next.js Route Handlers.
 command: npx servercn-cli@latest add response-formatter
 ---
 

--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -127,7 +127,7 @@
       "description": "A standardized, type-safe API response wrapper for Express and Next.js applications.",
       "type": "component",
       "status": "stable",
-      "frameworks": ["express", "nextjs"],
+      "frameworks": ["express", "nextjs", "nestjs"],
       "docs": "/docs/components/response-formatter"
     },
     {

--- a/apps/web/src/data/registry.json
+++ b/apps/web/src/data/registry.json
@@ -128,7 +128,10 @@
       "type": "component",
       "status": "stable",
       "frameworks": ["express", "nextjs", "nestjs"],
-      "docs": "/docs/components/response-formatter"
+      "docs": "/docs/components/response-formatter",
+      "meta": {
+        "new": true
+      }
     },
     {
       "slug": "async-handler",

--- a/apps/web/src/lib/source.ts
+++ b/apps/web/src/lib/source.ts
@@ -131,7 +131,7 @@ export function getRegistryTypeItems(
       slug: item.slug,
       frameworks: item.frameworks,
       meta: {
-        new: item.meta?.new,
+        new: item.meta?.new || false,
         databases: item.meta?.databases?.map(db => ({
           ...db,
           slug: `${framework}/${item.type}s/${db.slug}`


### PR DESCRIPTION
Update the component registry to list nestjs as a supported framework, and add comprehensive documentation covering installation, setup, and usage examples for the NestJS implementation of the response-formatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added NestJS support for the API Response Formatter, including setup instructions and usage examples.
  - Added framework selection to the documentation sidebar.
  - Enabled NestJS documentation navigation and updated framework availability indicators.
  - Added responsive framework tabs and smooth page scrolling.

- **Improvements**
  - Documentation pages now support dynamic rendering and cookie-based code themes.
  - Updated documentation links, navigation styling, and framework routing.
  - Marked the API Response Formatter as new and available for NestJS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->