### PR TITLE
feat(cli): add monorepo context check for local registry commands

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -42,7 +42,9 @@ async function main() {
 
   program
     .command("build")
-    .description("Build the project")
+    .description(
+      "[Maintainer only] Build registry artifacts (packages/registry -> apps/web/public/sr)"
+    )
     .option("--name <name>", "App name, website name")
     .option("--url <url>", "App URL, website URL")
     .action(async (options: buildTypeProps) => await build(options));

--- a/packages/cli/src/commands/_build/index.ts
+++ b/packages/cli/src/commands/_build/index.ts
@@ -5,11 +5,12 @@ import { glob } from "glob";
 import { processRegistryItem } from "./build.handlers";
 import {
   APP_NAME,
+  GITHUB_URL,
   RegistryTypeList,
   SERVERCN_URL
 } from "@/constants/app.constants";
 import type { RegistryType, RegistryItem, FrameworkType } from "@/types";
-import { paths } from "@/lib/paths";
+import { assertMonorepoContext, paths } from "@/lib/paths";
 import { logger } from "@/utils/logger";
 import { spinner } from "@/utils/spinner";
 import { highlighter } from "@/utils/highlighter";
@@ -20,6 +21,8 @@ export type buildTypeProps = {
 };
 
 export async function build(options: buildTypeProps) {
+  assertMonorepoContext("build");
+
   const buildSpin = spinner("Building ServerCN registry...").start();
 
   const index: {

--- a/packages/cli/src/lib/paths.ts
+++ b/packages/cli/src/lib/paths.ts
@@ -6,6 +6,27 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 import fs from "node:fs";
+import { logger } from "@/utils/logger";
+import { GITHUB_URL } from "@/constants/app.constants";
+
+/**
+ * Checks if the current runtime is inside the servercn monorepo.
+ * Returns true only if both 'packages' and 'apps' directories exist
+ * as siblings when walking up from the CLI source.
+ */
+export function isInMonorepo(): boolean {
+  let current = __dirname;
+  while (current !== path.parse(current).root) {
+    if (
+      fs.existsSync(path.join(current, "packages")) &&
+      fs.existsSync(path.join(current, "apps"))
+    ) {
+      return true;
+    }
+    current = path.join(current, "..");
+  }
+  return false;
+}
 
 /**
  * Resolves the monorepo root directory.
@@ -68,3 +89,42 @@ export const paths = {
       `packages/cli/src/templates/${runtime}/${framework}/${architecture}/${fileName}.hbs`
     )
 };
+
+/**
+ * Asserts that the CLI is running inside the servercn monorepo.
+ * Used for maintainer-only features (--local flag, build command).
+ * Exits the process with a helpful error message if not in the monorepo.
+ */
+export function assertMonorepoContext(context?: string) {
+  if (!isInMonorepo()) {
+    logger.break();
+    if (context === "--local") {
+      logger.error(
+        "The '--local' flag requires running inside the servercn monorepo."
+      );
+    } else if (context) {
+      logger.error(
+        `'${context}' requires running inside the servercn monorepo.`
+      );
+    } else {
+      logger.error(
+        "This command requires running inside the servercn monorepo."
+      );
+    }
+    logger.break();
+    logger.info(
+      "This is a development-only feature that reads registry items and templates from disk."
+    );
+    logger.info("For regular usage, run without '--local':");
+    logger.break();
+    logger.log("  $ npx servercn-cli@latest init");
+    logger.log("  $ npx servercn-cli@latest add <component-name>");
+    logger.log("  $ npx servercn-cli@latest list");
+    logger.break();
+    logger.info(
+      `Contributors: clone the monorepo from ${GITHUB_URL} and run commands inside it.`
+    );
+    logger.break();
+    process.exit(1);
+  }
+}

--- a/packages/cli/src/lib/registry-list.ts
+++ b/packages/cli/src/lib/registry-list.ts
@@ -1,6 +1,6 @@
 import fs from "fs-extra";
 import path from "node:path";
-import { paths } from "./paths";
+import { assertMonorepoContext, paths } from "./paths";
 import type { RegistryData, RegistryType } from "@/types";
 import { SERVERCN_URL } from "@/constants/app.constants";
 import { logger } from "@/utils/logger";
@@ -11,6 +11,7 @@ export async function loadRegistryItems(
   local: boolean = false
 ) {
   if (local) {
+    assertMonorepoContext("--local");
     const registryDir = paths.localRegistry(type);
     const files = await fs.readdir(registryDir);
 

--- a/packages/cli/src/lib/registry.ts
+++ b/packages/cli/src/lib/registry.ts
@@ -1,7 +1,7 @@
 import fs from "fs-extra";
 import path from "path";
 import { logger } from "@/utils/logger";
-import { paths } from "./paths";
+import { assertMonorepoContext, paths } from "./paths";
 import type { RegistryMap } from "@/types";
 import { capitalize } from "@/utils/capitalize";
 import { getRegistryLists } from "@/commands/list/list.handlers";
@@ -19,6 +19,7 @@ export async function getRegistry<T extends keyof RegistryMap>(
     : name;
 
   if (local) {
+    assertMonorepoContext("--local");
     const registryPath = paths.localRegistry(type);
     // console.log({
     //   registryPath


### PR DESCRIPTION
### Add monorepo context check for local registry commands

Add monorepo context validation for developer-only CLI commands:
- Add `isInMonorepo` helper to detect the monorepo root by checking for sibling `packages/` and `apps/` directories
- Add `assertMonorepoContext` that exits with clear error messages and setup guidance when running commands outside the monorepo

Update `loadRegistryItems` to assert monorepo context when using the `--local` flag, replacing cryptic filesystem errors with actionable steps for users.

### Update build cmd desc and add repo check

Update the build command's description to note it's maintainer-only and specify it builds registry artifacts from packages/registry to apps/web/public/sr.
Add an assertMonorepoContext check when using the --local flag to ensure registry operations run within the monorepo root.