### PR TITLE
docs: add NestJS component docs and fix llms.txt whitespace

### DIFF
--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -105,8 +105,6 @@
 - [Global Error Handling](https://www.servercn.xyz/docs/express/components/global-error-handler): is a core part of any production-ready Express application.
 - [Graceful Shutdown Handler](https://www.servercn.xyz/docs/express/components/shutdown-handler):  ensures that your Express application terminates safely and predictably when the process receives termination signals (like SIGTERM or SIGINT).
 - [Health Check](https://www.servercn.xyz/docs/express/components/health-check): provides health check endpoints for monitoring the health and availability of node.js applications.
-
-
 - [HTTP Status Codes](https://www.servercn.xyz/docs/express/components/http-status-codes): provides a centralized and type-safe way to reference HTTP status codes across your backend.
 - [JWT Utils Function](https://www.servercn.xyz/docs/express/components/jwt-utils): provides a production-ready authentication utility based on access tokens and refresh tokens for Express-based applications.
 - [Not Found Handler](https://www.servercn.xyz/docs/express/components/not-found-handler):  provides a centralized and consistent way to handle unmatched routes.
@@ -142,6 +140,9 @@
 - [File Upload (Cloudinary)](https://www.servercn.xyz/docs/nextjs/components/file-upload-cloudinary): omponent provides a standardized way to handle file uploads in Servercn using Cloudinary as the storage provider.
 - [File Upload (Imagekit)](https://www.servercn.xyz/docs/nextjs/components/file-upload-imagekit): omponent provides a standardized way to handle file uploads in Servercn using Imagekit as the storage provider.
 - - [Health Check](https://www.servercn.xyz/docs/nextjs/components/health-check): provides health check endpoints for monitoring the health and availability of node.js applications.
+
+### Nest.JS
+- [API Response Formatter](https://www.servercn.xyz/docs/nestjs/components/response-formatter): a consistent, type-safe response structure for NestJS APIs.
 
 
 ## Blueprints


### PR DESCRIPTION
Remove duplicate empty lines from the Express components section, and add a new NestJS documentation category with the API Response Formatter component entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected formatting in the Express.js components list.
  * Added a NestJS components section with an API Response Formatter link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->