### PR TITLE
feat(web): add cli/changelog docs, update hero section and 404 page

### DIFF
--- a/apps/web/src/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/src/app/docs/[[...slug]]/page.tsx
@@ -131,6 +131,10 @@ function getDocPath(slug?: string[]) {
     return path.join(DOCS_PATH, "guides", "getting-started.mdx");
   } else if (slug.length === 1 && slug[0] === "installation") {
     return path.join(DOCS_PATH, "guides", "installation.mdx");
+  } else if (slug.length === 1 && slug[0] === "cli") {
+    return path.join(DOCS_PATH, "guides", "cli.mdx");
+  } else if (slug.length === 1 && slug[0] === "changelog") {
+    return path.join(DOCS_PATH, "changelog", "index.mdx");
   }
 
   const actualSlug = slug;
@@ -202,6 +206,13 @@ export default async function DocsPage({
     // variant
   } = resolveRegistryItem(slug[slug.length - 1]);
 
+  const specialPages = [
+    "cli",
+    "guides",
+    "installation",
+    "introduction",
+    "contributing"
+  ];
 
   return (
     <>
@@ -212,13 +223,7 @@ export default async function DocsPage({
             <div className="mb-6 flex items-center justify-between pt-6">
               <div className="flex items-center gap-3">
                 <OpenInAi />
-                {![
-                  "cli",
-                  "guides",
-                  "installation",
-                  "introduction",
-                  "contributing"
-                ].includes(slug[0]) && (
+                {!specialPages.includes(slug[0]) && (
                   <ViewAsJson
                     type={
                       ["tooling"].includes(slug[0])
@@ -270,9 +275,11 @@ export default async function DocsPage({
               <p className="text-muted-foreground">{data.description}</p>
             </div>
 
-            <div className="mt-4 border-b pb-5">
-              <FrameworkTabs />
-            </div>
+            {!specialPages.includes(slug[0]) && (
+              <div className="mt-4 border-b pb-5">
+                <FrameworkTabs />
+              </div>
+            )}
             <MDXRemote
               source={content}
               components={mdxComponents}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,6 +1,6 @@
 export default function NotFound() {
   return (
-    <div className="border-edge screen-line-after mx-auto flex min-h-screen max-w-360 items-center justify-center overflow-x-hidden border-x">
+    <div className="border-edge screen-line-after mx-auto flex min-h-screen max-w-368 items-center justify-center overflow-x-hidden border-x">
       <div className="flex flex-col items-center space-y-6 p-6 text-center sm:p-12">
         <h1 className="font-mono text-6xl font-extrabold tracking-tight sm:text-8xl">
           404

--- a/apps/web/src/components/home/hero-section.tsx
+++ b/apps/web/src/components/home/hero-section.tsx
@@ -49,11 +49,14 @@ const supportedStack = [
     name: "Prisma",
     icon: LanguageIcons.prisma
   },
-
   {
     name: "Next.js",
     icon: LanguageIcons.nextjs
-  }
+  },
+  {
+    name: "Nest.js",
+    icon: LanguageIcons.nestjs
+  },
 ];
 
 export default function HeroSection() {
@@ -103,7 +106,7 @@ export default function HeroSection() {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.5, delay: 0.2 }}
-                className="mt-6 flex flex-wrap items-center gap-3">
+                className="mt-6 flex flex-wrap items-center gap-2">
                 {supportedStack.map(stack => (
                   <Tooltip key={stack.name}>
                     <TooltipTrigger className="cursor-pointer">


### PR DESCRIPTION
remove extra blank line in supported tech stack array add Nest.js to supported tech stack
adjust stack item gap from 3 to 2
refactor doc page special page checks to reuse exclusion list fix 404 page max width from 360 to 368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated routing for CLI and changelog documentation pages.
  * Added Nest.js to the supported technology stack display.

* **Bug Fixes**
  * Improved documentation page controls by hiding irrelevant options on special pages.
  * Adjusted the not-found page layout for improved sizing.

* **Style**
  * Refined spacing between supported technology icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->